### PR TITLE
[expo] add a workflow to run eas build locally on Github Actions.

### DIFF
--- a/.github/workflows/eas-build-local-ios.yml
+++ b/.github/workflows/eas-build-local-ios.yml
@@ -1,0 +1,46 @@
+name: EAS - build local iOS
+on:
+  workflow_dispatch:
+    inputs:
+      config:
+        description: "HPAPP_CONFIG_NAME set"
+        required: true
+        default: "dev"
+        type: choice
+        options:
+          - dev
+          - prod
+jobs:
+  build:
+    runs-on: macos-latest
+    environment:
+      name: eas-build-local-dev
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "yarn"
+          cache-dependency-path: "expo/package.json"
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: 5.4.0
+          token: ${{ secrets.EXPO_TOKEN }}
+      - run: yarn global add eas-cli-local-build-plugin
+      - run: cd expo && yarn install
+      - run: rm expo/config/dev/.gitignore
+      - run: echo -n "${{ secrets.GOOGLE_SERVICE_INFO_PLIST }}" |  base64 --decode > expo/config/${{inputs.config}}/GoogleService-Info.plist
+      - run: echo -n "${{ secrets.SECRETS_JSON }}" |  base64 --decode > expo/config/${{inputs.config}}/secrets.json
+      - run: cp expo/config/dev/eas.json expo/eas.json
+      - run: |
+          cd expo && \
+          eas build --local --non-interactive --output=./app-ios --profile=dev --platform=ios
+        env:
+          HPAPP_CONFIG_NAME: dev
+          HPAPP_CONFIG_PLATFORM: ios
+          GOOGLE_SERVICES_FILE: config/${{inputs.config}}/GoogleService-Info.plist
+      - name: 📱 Upload binary
+        uses: actions/upload-artifact@v2
+        with:
+          name: app-ios-${{inputs.config}}
+          path: expo/app-ios

--- a/expo/app.config.js
+++ b/expo/app.config.js
@@ -32,6 +32,9 @@ module.exports = (_) => {
     ? process.env[easEnvvarPrefix + "SECRETS_JSON"]
     : path.join("config", cfgName, "secrets.json");
 
+  console.log("isEAS", isEAS);
+  console.log(iosGoogleServicesFilePath);
+
   if (fs.existsSync(iosGoogleServicesFilePath)) {
     config.ios.googleServicesFile = iosGoogleServicesFilePath;
   }

--- a/expo/config/dev/eas.json
+++ b/expo/config/dev/eas.json
@@ -1,6 +1,6 @@
 {
   "cli": {
-    "version": "3.10.0"
+    "version": "5.4.0"
   },
   "build": {
     "dev": {


### PR DESCRIPTION
**Summary**

EAS costs $2 per a build and it can charge even if a build fails with a few seconds, which could be expensive than the local build on Github Actions.

We want to reduce the build cost so this PR tries to run eas build with --local option.

**Test**

- run workflow manually.

[Test run](https://github.com/yssk22/hpapp/actions/runs/6597486092/usage) costs 14 min / build * $0.08 / min = $1.12/build

We can use Github Actions for development build while we continue to use eas server build for production.

**Issue**

- N/A