### PR TITLE
[expo] add logging module to capture events locally

### DIFF
--- a/expo/app.config.js
+++ b/expo/app.config.js
@@ -3,12 +3,6 @@ const fs = require("fs");
 const config = require("./app.config.default").expo;
 
 module.exports = (_) => {
-  if (process.env["REACT_NATIVE_PACKAGER_HOSTNAME"] != "") {
-    config.extra.hpapp.graphql_endpoint =
-      "http://" +
-      process.env["REACT_NATIVE_PACKAGER_HOSTNAME"] +
-      ":8080/graphql/v3";
-  }
   const cfgName = process.env["HPAPP_CONFIG_NAME"];
   if (cfgName === undefined || cfgName === "") {
     throw new Error(
@@ -31,9 +25,6 @@ module.exports = (_) => {
   const secretsJsonPath = isEAS
     ? process.env[easEnvvarPrefix + "SECRETS_JSON"]
     : path.join("config", cfgName, "secrets.json");
-
-  console.log("isEAS", isEAS);
-  console.log(iosGoogleServicesFilePath);
 
   if (fs.existsSync(iosGoogleServicesFilePath)) {
     config.ios.googleServicesFile = iosGoogleServicesFilePath;

--- a/expo/assets/translations.json
+++ b/expo/assets/translations.json
@@ -60,6 +60,9 @@
   "Sync Events to Calendar": {
     "ja": "カレンダーにイベントを同期する"
   },
+  "Do not sync": {
+    "ja": "同期しない"
+  },
   "Event Prefix": {
     "ja": "イベントのプレフィックス"
   },

--- a/expo/system/logging/Console.ts
+++ b/expo/system/logging/Console.ts
@@ -1,0 +1,41 @@
+import { LogLevel, LogSink } from "@hpapp/system/logging/types";
+import Constants from "expo-constants";
+
+const consoleEvents: Array<RegExp> = (
+  Constants.expoConfig?.extra?.hpapp?.consoleEvents || []
+).map((re: string) => {
+  return new RegExp(re);
+});
+
+class Console implements LogSink {
+  constructor() {}
+  Log(
+    level: LogLevel,
+    event: string,
+    message: string,
+    data?: Record<string, any> | undefined
+  ): void {
+    // isFocus event
+    console.log(Constants.expoConfig?.extra?.hpapp?.consoleEvents);
+    const isFocus =
+      consoleEvents.filter((r) => {
+        return r.test(event);
+      }).length > 0;
+
+    if (level === "error") {
+      if (isFocus) {
+        console.error(event, message, JSON.stringify(data, null, "  "));
+      } else {
+        console.error(event, message);
+      }
+    } else {
+      if (isFocus) {
+        console.log(event, message, JSON.stringify(data, null, "  "));
+      } else {
+        console.log(event, message);
+      }
+    }
+  }
+}
+
+export default new Console();

--- a/expo/system/logging/index.ts
+++ b/expo/system/logging/index.ts
@@ -1,0 +1,20 @@
+import { LogLevel, LogSink } from "@hpapp/system/logging/types";
+import Console from "@hpapp/system/logging/Console";
+
+let sink: LogSink = Console;
+
+export function Info(
+  event: string,
+  message: string,
+  data?: Record<string, any>
+) {
+  sink.Log("info", event, message, data);
+}
+
+export function Error(
+  event: string,
+  message: string,
+  data?: Record<string, any>
+) {
+  sink.Log("error", event, message, data);
+}

--- a/expo/system/logging/types.ts
+++ b/expo/system/logging/types.ts
@@ -1,0 +1,10 @@
+export type LogLevel = "error" | "info";
+
+export interface LogSink {
+  Log(
+    level: LogLevel,
+    event: string,
+    message: string,
+    data?: Record<string, any>
+  ): void;
+}


### PR DESCRIPTION
**Summary**

One of opportunities in v2.x seriese is about logging. We didn't have a good methodology to get the application logs from the devices but we want to fix it for better triage process.

This PR adds a placeholder to capture logs and use console.log for the proof of concept.

We need to identify how to store logs on devices and upload to somewhere in the future.

**Test**

- expo

**Issue**

- N/A