### PR TITLE
[go][graphql] implement Node interface for HelloProject query

### DIFF
--- a/go/devtool/generator/graphql/schema/generator_test.go
+++ b/go/devtool/generator/graphql/schema/generator_test.go
@@ -62,7 +62,7 @@ enum MyEnum @goModel(model: "github.com/yssk22/hpapp/go/devtool/generator/graphq
   foo
 }
 
-type MyComplexType @goModel(model: "github.com/yssk22/hpapp/go/devtool/generator/graphql/schema/testdata.MyComplexType") implements MyInterface {
+type MyComplexType implements MyInterface @goModel(model: "github.com/yssk22/hpapp/go/devtool/generator/graphql/schema/testdata.MyComplexType") {
   id: ID!
   nested: NestedMyComplexType!
 

--- a/go/graphql/v3/generated/exec_generated.go
+++ b/go/graphql/v3/generated/exec_generated.go
@@ -407,6 +407,7 @@ type ComplexityRoot struct {
 	HelloProjectQuery struct {
 		Artists func(childComplexity int, after *entgql.Cursor[int], first *int, before *entgql.Cursor[int], last *int) int
 		Feed    func(childComplexity int, params helloproject.HPFeedQueryParams, after *entgql.Cursor[int], first *int, before *entgql.Cursor[int], last *int) int
+		ID      func(childComplexity int) int
 	}
 
 	MeMutation struct {
@@ -2330,6 +2331,13 @@ func (e *executableSchema) Complexity(typeName, field string, childComplexity in
 		}
 
 		return e.complexity.HelloProjectQuery.Feed(childComplexity, args["params"].(helloproject.HPFeedQueryParams), args["after"].(*entgql.Cursor[int]), args["first"].(*int), args["before"].(*entgql.Cursor[int]), args["last"].(*int)), true
+
+	case "HelloProjectQuery.id":
+		if e.complexity.HelloProjectQuery.ID == nil {
+			break
+		}
+
+		return e.complexity.HelloProjectQuery.ID(childComplexity), true
 
 	case "MeMutation.authenticate":
 		if e.complexity.MeMutation.Authenticate == nil {
@@ -15436,6 +15444,50 @@ func (ec *executionContext) fieldContext_HPViewHistoryEdge_cursor(ctx context.Co
 	return fc, nil
 }
 
+func (ec *executionContext) _HelloProjectQuery_id(ctx context.Context, field graphql.CollectedField, obj *helloproject.HelloProjectQuery) (ret graphql.Marshaler) {
+	fc, err := ec.fieldContext_HelloProjectQuery_id(ctx, field)
+	if err != nil {
+		return graphql.Null
+	}
+	ctx = graphql.WithFieldContext(ctx, fc)
+	defer func() {
+		if r := recover(); r != nil {
+			ec.Error(ctx, ec.Recover(ctx, r))
+			ret = graphql.Null
+		}
+	}()
+	resTmp, err := ec.ResolverMiddleware(ctx, func(rctx context.Context) (interface{}, error) {
+		ctx = rctx // use context from middleware stack in children
+		return obj.ID(), nil
+	})
+	if err != nil {
+		ec.Error(ctx, err)
+		return graphql.Null
+	}
+	if resTmp == nil {
+		if !graphql.HasFieldError(ctx, fc) {
+			ec.Errorf(ctx, "must not be null")
+		}
+		return graphql.Null
+	}
+	res := resTmp.(string)
+	fc.Result = res
+	return ec.marshalNID2string(ctx, field.Selections, res)
+}
+
+func (ec *executionContext) fieldContext_HelloProjectQuery_id(ctx context.Context, field graphql.CollectedField) (fc *graphql.FieldContext, err error) {
+	fc = &graphql.FieldContext{
+		Object:     "HelloProjectQuery",
+		Field:      field,
+		IsMethod:   true,
+		IsResolver: false,
+		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
+			return nil, errors.New("field of type ID does not have child fields")
+		},
+	}
+	return fc, nil
+}
+
 func (ec *executionContext) _HelloProjectQuery_artists(ctx context.Context, field graphql.CollectedField, obj *helloproject.HelloProjectQuery) (ret graphql.Marshaler) {
 	fc, err := ec.fieldContext_HelloProjectQuery_artists(ctx, field)
 	if err != nil {
@@ -17619,6 +17671,8 @@ func (ec *executionContext) fieldContext_Query_helloproject(ctx context.Context,
 		IsResolver: true,
 		Child: func(ctx context.Context, field graphql.CollectedField) (*graphql.FieldContext, error) {
 			switch field.Name {
+			case "id":
+				return ec.fieldContext_HelloProjectQuery_id(ctx, field)
 			case "artists":
 				return ec.fieldContext_HelloProjectQuery_artists(ctx, field)
 			case "feed":
@@ -21192,6 +21246,16 @@ func (ec *executionContext) _Node(ctx context.Context, sel ast.SelectionSet, obj
 	switch obj := (obj).(type) {
 	case nil:
 		return graphql.Null
+	case *helloproject.HelloProjectQuery:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._HelloProjectQuery(ctx, sel, obj)
+	case *me.MeQuery:
+		if obj == nil {
+			return graphql.Null
+		}
+		return ec._MeQuery(ctx, sel, obj)
 	case *ent.Auth:
 		if obj == nil {
 			return graphql.Null
@@ -23695,7 +23759,7 @@ func (ec *executionContext) _HPViewHistoryEdge(ctx context.Context, sel ast.Sele
 	return out
 }
 
-var helloProjectQueryImplementors = []string{"HelloProjectQuery"}
+var helloProjectQueryImplementors = []string{"HelloProjectQuery", "Node"}
 
 func (ec *executionContext) _HelloProjectQuery(ctx context.Context, sel ast.SelectionSet, obj *helloproject.HelloProjectQuery) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, helloProjectQueryImplementors)
@@ -23705,6 +23769,13 @@ func (ec *executionContext) _HelloProjectQuery(ctx context.Context, sel ast.Sele
 		switch field.Name {
 		case "__typename":
 			out.Values[i] = graphql.MarshalString("HelloProjectQuery")
+		case "id":
+
+			out.Values[i] = ec._HelloProjectQuery_id(ctx, field, obj)
+
+			if out.Values[i] == graphql.Null {
+				atomic.AddUint32(&invalids, 1)
+			}
 		case "artists":
 			field := field
 
@@ -23856,7 +23927,7 @@ func (ec *executionContext) _MeMutation(ctx context.Context, sel ast.SelectionSe
 	return out
 }
 
-var meQueryImplementors = []string{"MeQuery"}
+var meQueryImplementors = []string{"MeQuery", "Node"}
 
 func (ec *executionContext) _MeQuery(ctx context.Context, sel ast.SelectionSet, obj *me.MeQuery) graphql.Marshaler {
 	fields := graphql.CollectFields(ec.OperationContext, sel, meQueryImplementors)

--- a/go/graphql/v3/generated/schema.graphql
+++ b/go/graphql/v3/generated/schema.graphql
@@ -1,4 +1,5 @@
-type HelloProjectQuery @goModel(model: "github.com/yssk22/hpapp/go/graphql/v3/helloproject.HelloProjectQuery") {
+type HelloProjectQuery implements Node @goModel(model: "github.com/yssk22/hpapp/go/graphql/v3/helloproject.HelloProjectQuery") {
+  id: ID!
   artists(after: Cursor, first: Int, before: Cursor, last: Int): [HPArtist]
   feed(params: HPFeedQueryParamsInput!, after: Cursor, first: Int, before: Cursor, last: Int): HPFeedItemConnection
 }
@@ -18,7 +19,7 @@ enum HPAssetType @goModel(model: "github.com/yssk22/hpapp/go/service/schema/enum
   youtube
 }
 
-type MeQuery @goModel(model: "github.com/yssk22/hpapp/go/graphql/v3/me.MeQuery") {
+type MeQuery implements Node @goModel(model: "github.com/yssk22/hpapp/go/graphql/v3/me.MeQuery") {
   id: ID!
   username: String!
   clientId: String

--- a/go/graphql/v3/helloproject/query.go
+++ b/go/graphql/v3/helloproject/query.go
@@ -15,6 +15,12 @@ import (
 
 type HelloProjectQuery struct{}
 
+func (h *HelloProjectQuery) IsNode() {}
+
+func (h *HelloProjectQuery) ID() string {
+	return "helloproject"
+}
+
 func (h *HelloProjectQuery) Artists(ctx context.Context, after *ent.Cursor, first *int, before *ent.Cursor, last *int) ([]*ent.HPArtist, error) {
 	client := entutil.NewClient(ctx)
 	return client.HPArtist.Query().All(ctx)

--- a/go/graphql/v3/me/query.go
+++ b/go/graphql/v3/me/query.go
@@ -24,6 +24,8 @@ import (
 
 type MeQuery struct{}
 
+func (h *MeQuery) IsNode() {}
+
 func (h *MeQuery) ID(ctx context.Context) (string, error) {
 	return appuser.CurrentUser(ctx).ID(), nil
 }


### PR DESCRIPTION
**Summary**

This is required to use pagination under HelloProject query. Otherwise, we see the following error on relay.

````
Failed to build:
 - Validation errors:
 - Invalid use of @refetchable on fragment 'FeedQuery_helloproject_query_feed', only supported are fragments on:
 - the Viewer type
 - the Query type
 - the Node interface, object types that implement the Node interface, interfaces whose implementing objects all implement Node, and unions whose members all implement Node
 - server objects and interfaces with the @fetchable directive:features/feed/Feed.tsx:12:45
````

We use `ID()` method signature to identify if the struct implements Node or not but Node interface is mapped to ent.Noder interface, the struct has to implement `IsNode()` method as well.

**Test**

- go test

**Issue**

- N/A