### PR TITLE
[expo] add DevOnlySettingsScreen

### DIFF
--- a/expo/Screens.tsx
+++ b/expo/Screens.tsx
@@ -3,9 +3,10 @@
 import S0 from './features/auth/OAuthSettingsScreen';
 import S1 from './features/feed/FeedItemScreen';
 import S2 from './features/home/HomeScreen';
-import S3 from './features/settings/theme/ThemeColorSelectorScreen';
-import S4 from './features/settings/theme/ThemeSettingsScreen';
-import S5 from './features/upfc/settings/UPFCSettingsScreen';
+import S3 from './features/settings/devonly/DevOnlySettingsScreen';
+import S4 from './features/settings/theme/ThemeColorSelectorScreen';
+import S5 from './features/settings/theme/ThemeSettingsScreen';
+import S6 from './features/upfc/settings/UPFCSettingsScreen';
 
 const Screens = [
   S0,
@@ -14,5 +15,6 @@ const Screens = [
   S3,
   S4,
   S5,
+  S6,
 ];
 export default Screens;

--- a/expo/assets/translations.json
+++ b/expo/assets/translations.json
@@ -72,6 +72,9 @@
   "Clear": {
     "ja": "クリア"
   },
+  "Dev Only Settings": {
+    "ja": "開発者設定"
+  },
   "Logout": {
     "ja": "ログアウト"
   }

--- a/expo/contexts/settings/useLocalUserConfig.ts
+++ b/expo/contexts/settings/useLocalUserConfig.ts
@@ -13,6 +13,8 @@ type LocalUserConfiguration = {
 
   amebloOptimizedView: boolean;
   feedUseMemberTaggings: boolean;
+
+  adminEnableDevOnly: boolean;
 };
 
 const LocalUserConfigurationSettings =
@@ -32,6 +34,8 @@ const LocalUserConfigurationSettings =
 
         amebloOptimizedView: false,
         feedUseMemberTaggings: true,
+
+        adminEnableDevOnly: false,
       },
     }
   );

--- a/expo/features/auth/index.tsx
+++ b/expo/features/auth/index.tsx
@@ -1,0 +1,67 @@
+import { useSettings } from "@hpapp/contexts/settings";
+import { SecureStorage, SettingsStore } from "@hpapp/system/kvs";
+import React, { useCallback, useMemo } from "react";
+import * as logging from "@hpapp/system/logging";
+import * as object from "@hpapp/foundation/object";
+import useCurrentUser, {
+  CurrentUserSettings,
+} from "@hpapp/features/auth/useCurrentUser";
+import { User, UserRole } from "@hpapp/features/auth/types";
+import useUserRoles from "@hpapp/features/auth/useUserRoles";
+
+function TierGate({
+  allow,
+  deny,
+  children,
+}: {
+  allow?: UserRole | Array<UserRole>;
+  deny?: UserRole | Array<UserRole>;
+  children: React.ReactNode;
+}) {
+  const roles = useUserRoles();
+  return useMemo(() => {
+    if (allow) {
+      const allowedRoles = object.NormalizeA(allow);
+      for (let i in roles) {
+        const r = roles[i];
+        if (object.In(r, ...allowedRoles)) {
+          return <>{children}</>;
+        }
+      }
+      return <></>;
+    }
+    if (deny) {
+      const deniedRoles = object.NormalizeA(deny);
+      for (let i in roles) {
+        const r = roles[i];
+        if (object.In(r, ...deniedRoles)) {
+          return <></>;
+        }
+        return <>{children}</>;
+      }
+    }
+    throw new Error("none of allow nor deny is specified in TierGate");
+  }, [allow, deny, roles]);
+}
+
+function useLogout() {
+  const [user, setUser] = useCurrentUser();
+  return useCallback(() => {
+    setUser(null);
+  }, [setUser]);
+}
+
+type LoginContainer = React.ElementType<{
+  onAuthenticated: (user: User) => void;
+}>;
+
+export {
+  User,
+  UserRole,
+  CurrentUserSettings,
+  useCurrentUser,
+  useUserRoles,
+  TierGate,
+  useLogout,
+  LoginContainer,
+};

--- a/expo/features/auth/types.ts
+++ b/expo/features/auth/types.ts
@@ -1,0 +1,9 @@
+interface User {
+  id: string;
+  username: string;
+  accessToken: string;
+}
+
+type UserRole = "admin" | "developer" | "fcmember" | "user" | "guest";
+
+export { User, UserRole };

--- a/expo/features/auth/useCurrentUser.ts
+++ b/expo/features/auth/useCurrentUser.ts
@@ -1,13 +1,8 @@
+import { useCallback } from "react";
+import { User } from "@hpapp/features/auth/types";
 import { useSettings } from "@hpapp/contexts/settings";
 import { SecureStorage, SettingsStore } from "@hpapp/system/kvs";
-import React, { useCallback } from "react";
 import * as logging from "@hpapp/system/logging";
-
-interface User {
-  id: string;
-  username: string;
-  accessToken: string;
-}
 
 const storage = new SecureStorage();
 
@@ -17,7 +12,7 @@ const LegacyCurrentUserSettings = SettingsStore.register<User>(
   storage
 );
 
-const CurrentUserSettings = SettingsStore.register<User>(
+export const CurrentUserSettings = SettingsStore.register<User>(
   "hpapp.auth.current_user",
   storage,
   // migration from v2.x
@@ -26,7 +21,10 @@ const CurrentUserSettings = SettingsStore.register<User>(
   }
 );
 
-function useCurrentUser(): [User | undefined, (user: User | null) => void] {
+export default function useCurrentUser(): [
+  User | undefined,
+  (user: User | null) => void
+] {
   const [user, setUser] = useSettings(CurrentUserSettings);
   const setUserWithLoggig = useCallback(
     (update: User | null) => {
@@ -49,33 +47,3 @@ function useCurrentUser(): [User | undefined, (user: User | null) => void] {
   );
   return [user, setUserWithLoggig];
 }
-
-type UserTier = "admin" | "fcmember" | "normal" | "guest";
-
-function useUserTier(user: User | undefined): UserTier {
-  if (!user) {
-    return "guest";
-  }
-  return "normal";
-}
-
-function useLogout() {
-  const [user, setUser] = useCurrentUser();
-  return useCallback(() => {
-    setUser(null);
-  }, [setUser]);
-}
-
-type LoginContainer = React.ElementType<{
-  onAuthenticated: (user: User) => void;
-}>;
-
-export {
-  User,
-  CurrentUserSettings,
-  useCurrentUser,
-  useUserTier,
-  useLogout,
-  LoginContainer,
-  UserTier,
-};

--- a/expo/features/auth/useUserRoles.ts
+++ b/expo/features/auth/useUserRoles.ts
@@ -1,0 +1,30 @@
+import { useMemo } from "react";
+import useCurrentUser from "@hpapp/features/auth/useCurrentUser";
+import { User, UserRole } from "@hpapp/features/auth/types";
+
+const adminId = "42949672973"; // TODO: move it to secrets.json
+const developerId = "42949672973"; // TODO: move it to secrets.json
+
+export default function useUserRoles(user?: User): Array<UserRole> {
+  const [current] = useCurrentUser();
+  user = useMemo(() => {
+    return user == undefined ? current : user;
+  }, [user, current]);
+  return useMemo(() => {
+    const roles: Array<UserRole> = [];
+    if (user?.id == adminId) {
+      roles.push("admin");
+    }
+    if (user?.id == developerId) {
+      roles.push("developer");
+    }
+    if (typeof user?.id == "string") {
+      roles.push("user");
+    }
+    // TODO: fcmember
+    if (roles.length == 0) {
+      roles.push("guest");
+    }
+    return roles;
+  }, [user]);
+}

--- a/expo/features/settings/SettingsTab.tsx
+++ b/expo/features/settings/SettingsTab.tsx
@@ -1,4 +1,4 @@
-import { useLogout } from "@hpapp/features/auth";
+import { TierGate, useLogout } from "@hpapp/features/auth";
 import { View, Text, StyleSheet, ScrollView } from "react-native";
 import { Button, Divider } from "@rneui/themed";
 import NavigationListItem from "@hpapp/features/common/components/list/NavigationListItem";
@@ -8,6 +8,8 @@ import { t } from "@hpapp/system/i18n";
 import LogoutListItem from "@hpapp/features/settings/LogoutListItem";
 import VersionSignature from "@hpapp/features/settings/VersionSignature";
 import UPFCSettingsScreen from "@hpapp/features/upfc/settings/UPFCSettingsScreen";
+import DevOnly from "@hpapp/features/settings/devonly/DevOnly";
+import DevOnlySettingsScreen from "@hpapp/features/settings/devonly/DevOnlySettingsScreen";
 
 export default function SettingsTab() {
   return (
@@ -19,6 +21,12 @@ export default function SettingsTab() {
       <NavigationListItem screen={UPFCSettingsScreen}>
         {t("FC Settings")}
       </NavigationListItem>
+      <TierGate allow={"admin"}>
+        <Divider />
+        <NavigationListItem screen={DevOnlySettingsScreen}>
+          {t("Dev Only Settings")}
+        </NavigationListItem>
+      </TierGate>
       <Divider />
       <LogoutListItem />
       <Divider />

--- a/expo/features/settings/VersionSignature.tsx
+++ b/expo/features/settings/VersionSignature.tsx
@@ -1,4 +1,4 @@
-import { useCurrentUser, useUserTier } from "@hpapp/features/auth";
+import { useCurrentUser, useUserRoles } from "@hpapp/features/auth";
 import Link from "@hpapp/features/common/components/Link";
 import Text from "@hpapp/features/common/components/Text";
 import React from "react";
@@ -22,7 +22,7 @@ const styles = StyleSheet.create({
 
 const VersionSignature: React.FC = () => {
   const [user, _] = useCurrentUser();
-  const tier = useUserTier(user);
+  const roles = useUserRoles(user);
   return (
     <View style={styles.container}>
       <Link href="https://twitter.com/hellofanapp">
@@ -32,7 +32,7 @@ const VersionSignature: React.FC = () => {
         Version {ApplicationVersion} (Buld: {BuildNumber})
       </Text>
       <Text style={styles.text}>
-        ID: {user?.id} ({tier})
+        ID: {user?.id} ({roles.join(", ")})
       </Text>
     </View>
   );

--- a/expo/features/settings/devonly/DevOnly.tsx
+++ b/expo/features/settings/devonly/DevOnly.tsx
@@ -1,0 +1,5 @@
+import { TierGate } from "@hpapp/features/auth";
+
+export default function ({ children }: { children: React.ReactNode }) {
+  return <TierGate allow="developer">{children}</TierGate>;
+}

--- a/expo/features/settings/devonly/DevOnlySettingsListItem.tsx
+++ b/expo/features/settings/devonly/DevOnlySettingsListItem.tsx
@@ -1,0 +1,32 @@
+import Text from "@hpapp/features/common/components/Text";
+import { ListItem } from "@rneui/themed";
+
+export default function DevOnlySettingsListItem({
+  name,
+  value,
+  displayValue,
+}: {
+  name: string;
+  value: string;
+  displayValue?: string;
+}) {
+  return (
+    <>
+      <ListItem
+        onPress={() => {
+          // console output so that developer can copy on their terminal.
+          console.log("Settings", name, ":", value);
+        }}
+      >
+        <ListItem.Content>
+          <ListItem.Title>
+            <Text>{name}</Text>
+          </ListItem.Title>
+          <ListItem.Subtitle>
+            <Text>{displayValue || value}</Text>
+          </ListItem.Subtitle>
+        </ListItem.Content>
+      </ListItem>
+    </>
+  );
+}

--- a/expo/features/settings/devonly/DevOnlySettingsScreen.tsx
+++ b/expo/features/settings/devonly/DevOnlySettingsScreen.tsx
@@ -1,0 +1,30 @@
+import { defineScreen } from "@hpapp/features/root/protected/stack";
+import { useCurrentUser } from "@hpapp/features/auth";
+import DevOnlySettingsListItem from "@hpapp/features/settings/devonly/DevOnlySettingsListItem";
+import { Divider } from "@rneui/themed";
+import useLocalUserConfig from "@hpapp/contexts/settings/useLocalUserConfig";
+
+export default defineScreen(
+  "/settings/devonly/",
+  function DevOnlySettingsScreen() {
+    const [user] = useCurrentUser();
+    const [config] = useLocalUserConfig();
+    return (
+      <>
+        <DevOnlySettingsListItem name="User ID" value={user!.id} />
+        <Divider />
+        <DevOnlySettingsListItem
+          name="Access Token"
+          value={user!.accessToken}
+          displayValue={user!.accessToken.substring(0, 4) + "****"}
+        />
+        <Divider />
+        <DevOnlySettingsListItem
+          name="Local User Config"
+          value={JSON.stringify(config, null, 2)}
+        />
+        <Divider />
+      </>
+    );
+  }
+);

--- a/expo/foundation/object.ts
+++ b/expo/foundation/object.ts
@@ -2,4 +2,11 @@ function In<T>(v: T, ...list: T[]) {
   return list.filter((vv) => v == vv).length > 0;
 }
 
-export { In };
+function NormalizeA<T>(v: T | T[]) {
+  if (Array.isArray(v)) {
+    return v;
+  }
+  return [v];
+}
+
+export { In, NormalizeA };


### PR DESCRIPTION
**Summary**

During the development, we need to inspect some configurations stored on memory or local storage.

`DevOnlySettingsScreen` provides a way to confirm the current value.

**Test**

- expo

**Issue**

- N/A