### PR TITLE
[expo][fix] myViewHistory field with schema merge

### DIFF
--- a/expo/features/feed/Feed.tsx
+++ b/expo/features/feed/Feed.tsx
@@ -75,7 +75,7 @@ function FeedLoader({
     params: {
       assetTypes: assetTypes,
       memberIDs: memberIds,
-      useMemberTaggings: useMemberTaggings || true,
+      useMemberTaggings: useMemberTaggings,
       minPostAt: minPostAt,
     },
   });

--- a/expo/features/feed/FeedListItem.tsx
+++ b/expo/features/feed/FeedListItem.tsx
@@ -4,7 +4,6 @@ import { graphql, useFragment } from "react-relay";
 import ExternalImage from "@hpapp/features/common/components/image";
 import * as date from "@hpapp/foundation/date";
 import { useColor } from "@hpapp/contexts/settings/theme";
-import { Icon } from "@rneui/themed";
 import { IconSize, Spacing } from "@hpapp/features/common/constants";
 import AssetIcon from "@hpapp/features/feed/AssetIcon";
 import ListItem from "@hpapp/features/common/components/list/ListItem";
@@ -52,7 +51,7 @@ export default function FeedListItem({
       <View style={styles.titleAndMetadata}>
         <Text style={styles.title}>{item.title}</Text>
         <View style={styles.metadata}>
-          {/* TODO: AssetIcon needs rebuild: <AssetIcon type={item.assetType} size={IconSize.Small} /> */}
+          <AssetIcon type={item.assetType} size={IconSize.Small} />
           <Text style={styles.dateString}>{dateString}</Text>
           <FeedListItemViewHistoryIcon data={item} />
         </View>
@@ -83,6 +82,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
   },
   dateString: {
+    marginLeft: Spacing.XSmall,
     marginRight: Spacing.Small,
   },
   icon: {

--- a/expo/features/feed/__generated__/FeedListItemFragment.graphql.ts
+++ b/expo/features/feed/__generated__/FeedListItemFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f5595f200f7a1e3cac794cff1447652a>>
+ * @generated SignedSource<<6b957c316d972596acb53c00802c2df4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,15 +17,10 @@ export type FeedListItemFragment$data = {
   readonly imageURL: string | null;
   readonly ownerMember: {
     readonly id: string;
-    readonly key: string;
   } | null;
   readonly postAt: string;
   readonly sourceID: number;
   readonly sourceURL: string;
-  readonly taggedMembers: ReadonlyArray<{
-    readonly id: string;
-    readonly key: string;
-  }> | null;
   readonly title: string;
   readonly " $fragmentSpreads": FragmentRefs<"FeedListItemViewHistoryIconFragment">;
   readonly " $fragmentType": "FeedListItemFragment";
@@ -42,17 +37,7 @@ var v0 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-},
-v1 = [
-  (v0/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "key",
-    "storageKey": null
-  }
-];
+};
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -109,17 +94,9 @@ return {
       "kind": "LinkedField",
       "name": "ownerMember",
       "plural": false,
-      "selections": (v1/*: any*/),
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "HPMember",
-      "kind": "LinkedField",
-      "name": "taggedMembers",
-      "plural": true,
-      "selections": (v1/*: any*/),
+      "selections": [
+        (v0/*: any*/)
+      ],
       "storageKey": null
     },
     {
@@ -133,6 +110,6 @@ return {
 };
 })();
 
-(node as any).hash = "d54fab5bf167a458740ef1e842ea1ca5";
+(node as any).hash = "6b375a3caabd3a62a7f967e8409b71e5";
 
 export default node;

--- a/expo/features/feed/__generated__/FeedListItemViewHistoryIconFragment.graphql.ts
+++ b/expo/features/feed/__generated__/FeedListItemViewHistoryIconFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f842443b25fb94d7b1867c2bc420a067>>
+ * @generated SignedSource<<0e32b51cbb06752b84c227e117d45484>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -29,34 +29,29 @@ const node: ReaderFragment = {
   "name": "FeedListItemViewHistoryIconFragment",
   "selections": [
     {
-      "kind": "ClientExtension",
+      "alias": null,
+      "args": null,
+      "concreteType": "HPViewHistory",
+      "kind": "LinkedField",
+      "name": "myViewHistory",
+      "plural": false,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "HPViewHistory",
-          "kind": "LinkedField",
-          "name": "myViewHistory",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "id",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "isFavorite",
-              "storageKey": null
-            }
-          ],
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isFavorite",
           "storageKey": null
         }
-      ]
+      ],
+      "storageKey": null
     }
   ],
   "type": "HPFeedItem",

--- a/expo/features/feed/__generated__/FeedQuery.graphql.ts
+++ b/expo/features/feed/__generated__/FeedQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3c0487688286c50ffed240a614a96f98>>
+ * @generated SignedSource<<81f9b7fe7be8e199d741532063ca2010>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -71,17 +71,7 @@ v4 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-},
-v5 = [
-  (v4/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "key",
-    "storageKey": null
-  }
-];
+};
 return {
   "fragment": {
     "argumentDefinitions": [
@@ -205,42 +195,29 @@ return {
                         "kind": "LinkedField",
                         "name": "ownerMember",
                         "plural": false,
-                        "selections": (v5/*: any*/),
+                        "selections": [
+                          (v4/*: any*/)
+                        ],
                         "storageKey": null
                       },
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "HPMember",
+                        "concreteType": "HPViewHistory",
                         "kind": "LinkedField",
-                        "name": "taggedMembers",
-                        "plural": true,
-                        "selections": (v5/*: any*/),
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "ClientExtension",
+                        "name": "myViewHistory",
+                        "plural": false,
                         "selections": [
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "HPViewHistory",
-                            "kind": "LinkedField",
-                            "name": "myViewHistory",
-                            "plural": false,
-                            "selections": [
-                              (v4/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isFavorite",
-                                "storageKey": null
-                              }
-                            ],
+                            "kind": "ScalarField",
+                            "name": "isFavorite",
                             "storageKey": null
                           }
-                        ]
+                        ],
+                        "storageKey": null
                       },
                       {
                         "alias": null,
@@ -308,12 +285,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6d1acf92700acfa1e543426201e44e2b",
+    "cacheID": "0e64b6f01267415141c70b3db9c0c1ab",
     "id": null,
     "metadata": {},
     "name": "FeedQuery",
     "operationKind": "query",
-    "text": "query FeedQuery(\n  $params: HPFeedQueryParamsInput!\n  $first: Int\n  $after: Cursor\n) {\n  helloproject {\n    ...FeedQuery_helloproject_query_feed\n    id\n  }\n}\n\nfragment FeedListItemFragment on HPFeedItem {\n  id\n  title\n  sourceID\n  sourceURL\n  imageURL\n  assetType\n  postAt\n  ownerMember {\n    id\n    key\n  }\n  taggedMembers {\n    id\n    key\n  }\n}\n\nfragment FeedQuery_helloproject_query_feed on HelloProjectQuery {\n  feed(params: $params, first: $first, after: $after) {\n    edges {\n      node {\n        id\n        ...FeedListItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query FeedQuery(\n  $params: HPFeedQueryParamsInput!\n  $first: Int\n  $after: Cursor\n) {\n  helloproject {\n    ...FeedQuery_helloproject_query_feed\n    id\n  }\n}\n\nfragment FeedListItemFragment on HPFeedItem {\n  id\n  title\n  sourceID\n  sourceURL\n  imageURL\n  assetType\n  postAt\n  ownerMember {\n    id\n  }\n  ...FeedListItemViewHistoryIconFragment\n}\n\nfragment FeedListItemViewHistoryIconFragment on HPFeedItem {\n  myViewHistory {\n    id\n    isFavorite\n  }\n}\n\nfragment FeedQuery_helloproject_query_feed on HelloProjectQuery {\n  feed(params: $params, first: $first, after: $after) {\n    edges {\n      node {\n        id\n        ...FeedListItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/expo/features/feed/__generated__/FeedQueryFragmentQuery.graphql.ts
+++ b/expo/features/feed/__generated__/FeedQueryFragmentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2619c665740770a65584e0b47db96364>>
+ * @generated SignedSource<<bf29cfa3264d39d3b58b32adf97b4552>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -90,16 +90,6 @@ v7 = [
     "kind": "Variable",
     "name": "params",
     "variableName": "params"
-  }
-],
-v8 = [
-  (v6/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "key",
-    "storageKey": null
   }
 ];
 return {
@@ -232,42 +222,29 @@ return {
                             "kind": "LinkedField",
                             "name": "ownerMember",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": [
+                              (v6/*: any*/)
+                            ],
                             "storageKey": null
                           },
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "HPMember",
+                            "concreteType": "HPViewHistory",
                             "kind": "LinkedField",
-                            "name": "taggedMembers",
-                            "plural": true,
-                            "selections": (v8/*: any*/),
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "ClientExtension",
+                            "name": "myViewHistory",
+                            "plural": false,
                             "selections": [
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
-                                "concreteType": "HPViewHistory",
-                                "kind": "LinkedField",
-                                "name": "myViewHistory",
-                                "plural": false,
-                                "selections": [
-                                  (v6/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isFavorite",
-                                    "storageKey": null
-                                  }
-                                ],
+                                "kind": "ScalarField",
+                                "name": "isFavorite",
                                 "storageKey": null
                               }
-                            ]
+                            ],
+                            "storageKey": null
                           },
                           (v5/*: any*/)
                         ],
@@ -332,12 +309,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "195787b3f0ffb87f0a5d49be5bb9ef45",
+    "cacheID": "3c6a23324ea6a85fe20a5f0b43f7bd86",
     "id": null,
     "metadata": {},
     "name": "FeedQueryFragmentQuery",
     "operationKind": "query",
-    "text": "query FeedQueryFragmentQuery(\n  $after: Cursor\n  $first: Int\n  $params: HPFeedQueryParamsInput!\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...FeedQuery_helloproject_query_feed\n    id\n  }\n}\n\nfragment FeedListItemFragment on HPFeedItem {\n  id\n  title\n  sourceID\n  sourceURL\n  imageURL\n  assetType\n  postAt\n  ownerMember {\n    id\n    key\n  }\n  taggedMembers {\n    id\n    key\n  }\n}\n\nfragment FeedQuery_helloproject_query_feed on HelloProjectQuery {\n  feed(params: $params, first: $first, after: $after) {\n    edges {\n      node {\n        id\n        ...FeedListItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query FeedQueryFragmentQuery(\n  $after: Cursor\n  $first: Int\n  $params: HPFeedQueryParamsInput!\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...FeedQuery_helloproject_query_feed\n    id\n  }\n}\n\nfragment FeedListItemFragment on HPFeedItem {\n  id\n  title\n  sourceID\n  sourceURL\n  imageURL\n  assetType\n  postAt\n  ownerMember {\n    id\n  }\n  ...FeedListItemViewHistoryIconFragment\n}\n\nfragment FeedListItemViewHistoryIconFragment on HPFeedItem {\n  myViewHistory {\n    id\n    isFavorite\n  }\n}\n\nfragment FeedQuery_helloproject_query_feed on HelloProjectQuery {\n  feed(params: $params, first: $first, after: $after) {\n    edges {\n      node {\n        id\n        ...FeedListItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();

--- a/expo/generated/schema.graphql
+++ b/expo/generated/schema.graphql
@@ -1,5 +1,64 @@
 directive @goField(forceResolver: Boolean, name: String) on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
 directive @goModel(model: String, models: [String!]) on OBJECT | INPUT_OBJECT | SCALAR | ENUM | INTERFACE | UNION
+
+type Query {
+  helloproject: HelloProjectQuery!
+  me: MeQuery!
+  """Fetches an object given its ID."""
+  node(
+    """ID of the object."""
+    id: ID!
+  ): Node
+  """Lookup nodes by a list of IDs."""
+  nodes(
+    """The list of node IDs."""
+    ids: [ID!]!
+  ): [Node]!
+}
+
+scalar Time
+
+scalar Upload
+
+scalar Any
+
+scalar Map
+
+type HPEvent implements Node {
+  tickets: [HPFCEventTicket!]
+  id: ID!
+  createdAt: Time
+  updatedAt: Time
+  key: String!
+  displayTitles: [String!]!
+  openAt: Time
+  startAt: Time!
+  venue: String!
+  prefecture: String!
+  source: HPEventHPEventSource!
+}
+
+type HPFeedItem implements Node {
+  myViewHistory: HPViewHistory
+  id: ID!
+  createdAt: Time
+  updatedAt: Time
+  sourceID: Int!
+  assetType: HPFeedItemHPAssetType!
+  title: String!
+  postAt: Time!
+  sourceURL: String!
+  imageURL: String
+  media: [Media!]!
+  ownerArtistID: ID
+  ownerMemberID: ID
+  ownerArtist: HPArtist
+  ownerMember: HPMember
+  taggedArtists: [HPArtist!]
+  taggedMembers: [HPMember!]
+}
+
 type Auth implements Node {
   id: ID!
   createdAt: Time
@@ -7,11 +66,13 @@ type Auth implements Node {
   """oauth provider name"""
   providerName: String!
 }
+
 """
 Define a Relay Cursor type:
 https://relay.dev/graphql/connections.htm#sec-Cursor
 """
 scalar Cursor
+
 type HPAmebloPost implements Node {
   id: ID!
   crawledAt: Time
@@ -42,12 +103,14 @@ type HPAmebloPost implements Node {
   taggedMembers: [HPMember!]
   blobs: [HPBlob!]
 }
+
 """HPAmebloPostSource is enum for the field source"""
 enum HPAmebloPostSource @goModel(model: "github.com/yssk22/hpapp/go/service/ent/hpameblopost.Source") {
   rss
   list
   entry
 }
+
 type HPArtist implements Node {
   id: ID!
   crawledAt: Time
@@ -62,6 +125,7 @@ type HPArtist implements Node {
   index: Int!
   members: [HPMember!]
 }
+
 type HPBlob implements Node {
   id: ID!
   createdAt: Time
@@ -88,7 +152,10 @@ type HPBlob implements Node {
   amebloPosts: [HPAmebloPost!]
   igPosts: [HPIgPost!]
 }
-"""HPBlobHPBlobFaceRecognitionStatus is enum for the field face_recognition_status"""
+
+"""
+HPBlobHPBlobFaceRecognitionStatus is enum for the field face_recognition_status
+"""
 enum HPBlobHPBlobFaceRecognitionStatus @goModel(model: "github.com/yssk22/hpapp/go/service/schema/enums.HPBlobFaceRecognitionStatus") {
   error
   face_automatically_labeled
@@ -96,6 +163,7 @@ enum HPBlobHPBlobFaceRecognitionStatus @goModel(model: "github.com/yssk22/hpapp/
   face_manually_labeled
   unknown
 }
+
 """HPBlobHPBlobStatus is enum for the field status"""
 enum HPBlobHPBlobStatus @goModel(model: "github.com/yssk22/hpapp/go/service/schema/enums.HPBlobStatus") {
   error
@@ -103,6 +171,7 @@ enum HPBlobHPBlobStatus @goModel(model: "github.com/yssk22/hpapp/go/service/sche
   ready_to_host
   unknown
 }
+
 """HPBlobHPBlobSubType is enum for the field sub_type"""
 enum HPBlobHPBlobSubType @goModel(model: "github.com/yssk22/hpapp/go/service/schema/enums.HPBlobSubType") {
   html
@@ -110,6 +179,7 @@ enum HPBlobHPBlobSubType @goModel(model: "github.com/yssk22/hpapp/go/service/sch
   mp4
   unknown
 }
+
 """HPBlobHPBlobType is enum for the field type"""
 enum HPBlobHPBlobType @goModel(model: "github.com/yssk22/hpapp/go/service/schema/enums.HPBlobType") {
   image
@@ -117,6 +187,7 @@ enum HPBlobHPBlobType @goModel(model: "github.com/yssk22/hpapp/go/service/schema
   unknown
   video
 }
+
 type HPElineupMallItem implements Node {
   id: ID!
   crawledAt: Time
@@ -139,7 +210,10 @@ type HPElineupMallItem implements Node {
   taggedArtists: [HPArtist!]
   taggedMembers: [HPMember!]
 }
-"""HPElineupMallItemHPElineupMallItemCategory is enum for the field category"""
+
+"""
+HPElineupMallItemHPElineupMallItemCategory is enum for the field category
+"""
 enum HPElineupMallItemHPElineupMallItemCategory @goModel(model: "github.com/yssk22/hpapp/go/service/schema/enums.HPElineupMallItemCategory") {
   Blueray
   ClearFile
@@ -166,18 +240,7 @@ enum HPElineupMallItemHPElineupMallItemCategory @goModel(model: "github.com/yssk
   PhotoOther
   TShirt
 }
-type HPEvent implements Node {
-  id: ID!
-  createdAt: Time
-  updatedAt: Time
-  key: String!
-  displayTitles: [String!]!
-  openAt: Time
-  startAt: Time!
-  venue: String!
-  prefecture: String!
-  source: HPEventHPEventSource!
-}
+
 """A connection to a list of items."""
 type HPEventConnection {
   """A list of edges."""
@@ -187,6 +250,7 @@ type HPEventConnection {
   """Identifies the total count of items in the connection."""
   totalCount: Int!
 }
+
 """An edge in a connection."""
 type HPEventEdge {
   """The item at the end of the edge."""
@@ -194,10 +258,12 @@ type HPEventEdge {
   """A cursor for use in pagination."""
   cursor: Cursor!
 }
+
 """HPEventHPEventSource is enum for the field source"""
 enum HPEventHPEventSource @goModel(model: "github.com/yssk22/hpapp/go/service/schema/enums.HPEventSource") {
   fc_scrape
 }
+
 type HPFCEventTicket implements Node {
   id: ID!
   createdAt: Time
@@ -212,6 +278,7 @@ type HPFCEventTicket implements Node {
   paymentStartDate: Time
   paymentDueDate: Time
 }
+
 """HPFCEventTicketHPEventFCTicketStatus is enum for the field status"""
 enum HPFCEventTicketHPEventFCTicketStatus @goModel(model: "github.com/yssk22/hpapp/go/service/schema/enums.HPEventFCTicketStatus") {
   Completed
@@ -221,24 +288,7 @@ enum HPFCEventTicketHPEventFCTicketStatus @goModel(model: "github.com/yssk22/hpa
   Submitted
   Unknown
 }
-type HPFeedItem implements Node {
-  id: ID!
-  createdAt: Time
-  updatedAt: Time
-  sourceID: Int!
-  assetType: HPFeedItemHPAssetType!
-  title: String!
-  postAt: Time!
-  sourceURL: String!
-  imageURL: String
-  media: [Media!]!
-  ownerArtistID: ID
-  ownerMemberID: ID
-  ownerArtist: HPArtist
-  ownerMember: HPMember
-  taggedArtists: [HPArtist!]
-  taggedMembers: [HPMember!]
-}
+
 """A connection to a list of items."""
 type HPFeedItemConnection {
   """A list of edges."""
@@ -248,6 +298,7 @@ type HPFeedItemConnection {
   """Identifies the total count of items in the connection."""
   totalCount: Int!
 }
+
 """An edge in a connection."""
 type HPFeedItemEdge {
   """The item at the end of the edge."""
@@ -255,6 +306,7 @@ type HPFeedItemEdge {
   """A cursor for use in pagination."""
   cursor: Cursor!
 }
+
 """HPFeedItemHPAssetType is enum for the field asset_type"""
 enum HPFeedItemHPAssetType @goModel(model: "github.com/yssk22/hpapp/go/service/schema/enums.HPAssetType") {
   ameblo
@@ -264,6 +316,7 @@ enum HPFeedItemHPAssetType @goModel(model: "github.com/yssk22/hpapp/go/service/s
   twitter
   youtube
 }
+
 """Ordering options for HPFeedItem connections"""
 input HPFeedItemOrder {
   """The ordering direction."""
@@ -271,10 +324,12 @@ input HPFeedItemOrder {
   """The field by which to order HPFeedItems."""
   field: HPFeedItemOrderField!
 }
+
 """Properties by which HPFeedItem connections can be ordered."""
 enum HPFeedItemOrderField {
   postAt
 }
+
 type HPFollow implements Node {
   id: ID!
   createdAt: Time
@@ -283,12 +338,14 @@ type HPFollow implements Node {
   user: User!
   member: HPMember!
 }
+
 """HPFollowHPFollowType is enum for the field type"""
 enum HPFollowHPFollowType @goModel(model: "github.com/yssk22/hpapp/go/service/schema/enums.HPFollowType") {
   follow
   follow_with_notification
   unfollow
 }
+
 type HPIgPost implements Node {
   id: ID!
   crawledAt: Time
@@ -312,6 +369,7 @@ type HPIgPost implements Node {
   taggedMembers: [HPMember!]
   blobs: [HPBlob!]
 }
+
 """A connection to a list of items."""
 type HPIgPostConnection {
   """A list of edges."""
@@ -321,6 +379,7 @@ type HPIgPostConnection {
   """Identifies the total count of items in the connection."""
   totalCount: Int!
 }
+
 """An edge in a connection."""
 type HPIgPostEdge {
   """The item at the end of the edge."""
@@ -328,6 +387,7 @@ type HPIgPostEdge {
   """A cursor for use in pagination."""
   cursor: Cursor!
 }
+
 type HPMember implements Node {
   id: ID!
   crawledAt: Time
@@ -349,6 +409,7 @@ type HPMember implements Node {
   artistID: ID
   artist: HPArtist
 }
+
 """A connection to a list of items."""
 type HPMemberConnection {
   """A list of edges."""
@@ -358,6 +419,7 @@ type HPMemberConnection {
   """Identifies the total count of items in the connection."""
   totalCount: Int!
 }
+
 """An edge in a connection."""
 type HPMemberEdge {
   """The item at the end of the edge."""
@@ -365,6 +427,7 @@ type HPMemberEdge {
   """A cursor for use in pagination."""
   cursor: Cursor!
 }
+
 type HPSortHistory implements Node {
   id: ID!
   createdAt: Time
@@ -372,6 +435,7 @@ type HPSortHistory implements Node {
   sortResult: HPSortResult!
   owner: User
 }
+
 """A connection to a list of items."""
 type HPSortHistoryConnection {
   """A list of edges."""
@@ -381,6 +445,7 @@ type HPSortHistoryConnection {
   """Identifies the total count of items in the connection."""
   totalCount: Int!
 }
+
 """An edge in a connection."""
 type HPSortHistoryEdge {
   """The item at the end of the edge."""
@@ -388,6 +453,7 @@ type HPSortHistoryEdge {
   """A cursor for use in pagination."""
   cursor: Cursor!
 }
+
 type HPViewHistory implements Node {
   id: ID!
   createdAt: Time
@@ -399,6 +465,7 @@ type HPViewHistory implements Node {
   isFavorite: Boolean!
   feed: HPFeedItem
 }
+
 """A connection to a list of items."""
 type HPViewHistoryConnection {
   """A list of edges."""
@@ -408,6 +475,7 @@ type HPViewHistoryConnection {
   """Identifies the total count of items in the connection."""
   totalCount: Int!
 }
+
 """An edge in a connection."""
 type HPViewHistoryEdge {
   """The item at the end of the edge."""
@@ -415,6 +483,7 @@ type HPViewHistoryEdge {
   """A cursor for use in pagination."""
   cursor: Cursor!
 }
+
 """HPViewHistoryHPAssetType is enum for the field asset_type"""
 enum HPViewHistoryHPAssetType @goModel(model: "github.com/yssk22/hpapp/go/service/schema/enums.HPAssetType") {
   ameblo
@@ -424,6 +493,7 @@ enum HPViewHistoryHPAssetType @goModel(model: "github.com/yssk22/hpapp/go/servic
   twitter
   youtube
 }
+
 """
 An object with an ID.
 Follows the [Relay Global Object Identification Specification](https://relay.dev/graphql/objectidentification.htm)
@@ -432,13 +502,17 @@ interface Node @goModel(model: "github.com/yssk22/hpapp/go/service/ent.Noder") {
   """The id of the object."""
   id: ID!
 }
-"""Possible directions in which to order a list of items when provided an `orderBy` argument."""
+
+"""
+Possible directions in which to order a list of items when provided an `orderBy` argument.
+"""
 enum OrderDirection {
   """Specifies an ascending order for a given `orderBy` argument."""
   ASC
   """Specifies a descending order for a given `orderBy` argument."""
   DESC
 }
+
 """
 Information about pagination in a connection.
 https://relay.dev/graphql/connections.htm#sec-undefined.PageInfo
@@ -453,18 +527,7 @@ type PageInfo {
   """When paginating forwards, the cursor to continue."""
   endCursor: Cursor
 }
-type Query {
-  """Fetches an object given its ID."""
-  node(
-    """ID of the object."""
-    id: ID!
-  ): Node
-  """Lookup nodes by a list of IDs."""
-  nodes(
-    """The list of node IDs."""
-    ids: [ID!]!
-  ): [Node]!
-}
+
 type User implements Node {
   id: ID!
   createdAt: Time
@@ -480,6 +543,7 @@ type User implements Node {
   hpsortHistory: [HPSortHistory!]
   hpfcEventTickets: [HPFCEventTicket!]
 }
+
 type UserNotificationSetting implements Node {
   id: ID!
   createdAt: Time
@@ -498,6 +562,7 @@ type UserNotificationSetting implements Node {
   enablePaymentDue: Boolean!
   user: User
 }
+
 type HelloProjectQuery implements Node @goModel(model: "github.com/yssk22/hpapp/go/graphql/v3/helloproject.HelloProjectQuery") {
   id: ID!
   artists(after: Cursor, first: Int, before: Cursor, last: Int): [HPArtist]
@@ -630,7 +695,6 @@ type ReactNavigationPush @goModel(model: "github.com/yssk22/hpapp/go/service/sch
   path: String!
   params: Map
   pushMessage: ExpoPushMessage!
-
   toPushMessage(tokens: [String!]): Message
 }
 
@@ -698,36 +762,7 @@ type HPIgCrawlArgsChildPost @goModel(model: "github.com/yssk22/hpapp/go/service/
   videoViewCount: Int!
 }
 
-type Query {
-  helloproject: HelloProjectQuery!
-  me: MeQuery!
-}
-
-scalar Time
-scalar Upload
-scalar Any
-scalar Map
-
-extend type HPEvent {
-  tickets: [HPFCEventTicket!]
-}
-
-extend type HPFeedItem {
-  myViewHistory: HPViewHistory
-}
-type Query {
-
-  """Fetches an object given its ID."""
-  node(
-    """ID of the object."""
-    id: ID!
-  ): Node
-  """Lookup nodes by a list of IDs."""
-  nodes(
-    """The list of node IDs."""
-    ids: [ID!]!
-  ): [Node]!
-
-  helloproject: HelloProjectQuery!
-  me: MeQuery!
+schema {
+  query: Query
+  mutation: Mutation
 }

--- a/expo/package.json
+++ b/expo/package.json
@@ -76,6 +76,9 @@
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",
+    "@graphql-tools/load-files": "^7.0.0",
+    "@graphql-tools/merge": "^9.0.0",
+    "@graphql-tools/schema": "^10.0.0",
     "@testing-library/react-native": "^12.0.1",
     "@types/jest": "^29.5.1",
     "@types/react": "~18.0.14",

--- a/expo/scripts/genschema.js
+++ b/expo/scripts/genschema.js
@@ -1,38 +1,22 @@
 #!/usr/bin/env node
+const {
+  makeExecutableSchema,
+  mergeSchemas,
+  printSchema,
+} = require("@graphql-tools/schema");
+const { loadFilesSync } = require("@graphql-tools/load-files");
+const { mergeTypeDefs, printMergedTypeDefs } = require("@graphql-tools/merge");
+const { print } = require("graphql");
 const fs = require("fs");
 const path = require("path");
 const package = require(path.join(__dirname, "..", "package.json"));
 
 const version = package.hpapp.graphql_version;
 
-const dst = path.join(__dirname, "..", "generated", "schema.graphql");
 const src = path.join(__dirname, "..", "..", "go", "graphql", version);
+const typesArray = loadFilesSync(src);
+const mergedSchema = mergeTypeDefs(typesArray);
+const schemaString = print(mergedSchema);
+const dst = path.join(__dirname, "..", "generated", "schema.graphql");
 
-const entSchema = fs
-  .readFileSync(path.join(src, "generated", "ent.graphql"))
-  .toString();
-const appSchema = fs
-  .readFileSync(path.join(src, "generated", "schema.graphql"))
-  .toString();
-const commonSchema = fs
-  .readFileSync(path.join(src, version + ".graphql"))
-  .toString();
-
-querySchemaEnt = entSchema.match(/type\s+Query\s+{([^}]+)}/)[1];
-querySchemaCommon = commonSchema.match(/type\s+Query\s+{([^}]+)}/)[1];
-
-const fd = fs.openSync(dst, "w");
-fs.writeSync(fd, entSchema);
-fs.writeSync(fd, appSchema);
-fs.writeSync(
-  fd,
-  // HACK:
-  //    DO NOT extend type Query as it is interpreted as client schema instead of server schema by relay-compiler.
-  //    see also https://relay.dev/docs/guides/client-schema-extensions/
-  //
-  //    there should be one Query definition in entSchema, and one extend Query defition from the app and we have to merge it into one Query type.
-  //
-  commonSchema.toString().replace(/extend type Query/, "type Query")
-);
-fs.writeSync(fd, "type Query {\n" + querySchemaEnt + querySchemaCommon + "}\n");
-fs.close(fd);
+fs.writeFileSync(dst, schemaString);

--- a/expo/yarn.lock
+++ b/expo/yarn.lock
@@ -1643,7 +1643,43 @@
   resolved "https://registry.yarnpkg.com/@gar/promisify/-/promisify-1.1.3.tgz#555193ab2e3bb3b6adc3d551c9c030d9e860daf6"
   integrity sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==
 
-"@graphql-typed-document-node/core@^3.1.0":
+"@graphql-tools/load-files@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/load-files/-/load-files-7.0.0.tgz#206833042c9c6fdf089996accb065ae448ba6819"
+  integrity sha512-P98amERIwI7FD8Bsq6xUbz9Mj63W8qucfrE/WQjad5jFMZYdFFt46a99FFdfx8S/ZYgpAlj/AZbaTtWLitMgNQ==
+  dependencies:
+    globby "11.1.0"
+    tslib "^2.4.0"
+    unixify "1.0.0"
+
+"@graphql-tools/merge@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-9.0.0.tgz#b0a3636c82716454bff88e9bb40108b0471db281"
+  integrity sha512-J7/xqjkGTTwOJmaJQJ2C+VDBDOWJL3lKrHJN4yMaRLAJH3PosB7GiPRaSDZdErs0+F77sH2MKs2haMMkywzx7Q==
+  dependencies:
+    "@graphql-tools/utils" "^10.0.0"
+    tslib "^2.4.0"
+
+"@graphql-tools/schema@^10.0.0":
+  version "10.0.0"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-10.0.0.tgz#7b5f6b6a59f51c927de8c9069bde4ebbfefc64b3"
+  integrity sha512-kf3qOXMFcMs2f/S8Y3A8fm/2w+GaHAkfr3Gnhh2LOug/JgpY/ywgFVxO3jOeSpSEdoYcDKLcXVjMigNbY4AdQg==
+  dependencies:
+    "@graphql-tools/merge" "^9.0.0"
+    "@graphql-tools/utils" "^10.0.0"
+    tslib "^2.4.0"
+    value-or-promise "^1.0.12"
+
+"@graphql-tools/utils@^10.0.0":
+  version "10.0.7"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-10.0.7.tgz#ed88968b5ce53dabacbdd185df967aaab35f8549"
+  integrity sha512-KOdeMj6Hd/MENDaqPbws3YJl3wVy0DeYnL7PyUms5Skyf7uzI9INynDwPMhLXfSb0/ph6BXTwMd5zBtWbF8tBQ==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    dset "^3.1.2"
+    tslib "^2.4.0"
+
+"@graphql-typed-document-node/core@^3.1.0", "@graphql-typed-document-node/core@^3.1.1":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
   integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
@@ -4236,6 +4272,11 @@ dotenv@16.0.3:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.0.3.tgz#115aec42bac5053db3c456db30cc243a5a836a07"
   integrity sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==
 
+dset@^3.1.2:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/dset/-/dset-3.1.3.tgz#c194147f159841148e8e34ca41f638556d9542d2"
+  integrity sha512-20TuZZHCEZ2O71q9/+8BwKwZ0QtD9D8ObhrihJPr+vLLYlSuAU3/zL4cSlgbfeoGHTjCSJBa7NGcrF9/Bx/WJQ==
+
 dtrace-provider@~0.8:
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.8.tgz#2996d5490c37e1347be263b423ed7b297fb0d97e"
@@ -5267,7 +5308,7 @@ globals@^11.1.0:
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
-globby@^11.0.1, globby@^11.1.0:
+globby@11.1.0, globby@^11.0.1, globby@^11.1.0:
   version "11.1.0"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.1.0.tgz#bd4be98bb042f83d796f7e3811991fbe82a0d34b"
   integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
@@ -7474,6 +7515,13 @@ normalize-css-color@^1.0.2:
   resolved "https://registry.yarnpkg.com/normalize-css-color/-/normalize-css-color-1.0.2.tgz#02991e97cccec6623fe573afbbf0de6a1f3e9f8d"
   integrity sha512-jPJ/V7Cp1UytdidsPqviKEElFQJs22hUUgK5BOPHTwOonNCk7/2qOxhhqzEajmFrWJowADFfOFh1V+aWkRfy+w==
 
+normalize-path@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
+  integrity sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==
+  dependencies:
+    remove-trailing-separator "^1.0.1"
+
 normalize-path@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
@@ -8455,6 +8503,11 @@ relay-runtime@15.0.0:
     "@babel/runtime" "^7.0.0"
     fbjs "^3.0.2"
     invariant "^2.2.4"
+
+remove-trailing-separator@^1.0.1:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"
+  integrity sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==
 
 remove-trailing-slash@^0.1.0:
   version "0.1.1"
@@ -9639,6 +9692,13 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
+unixify@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/unixify/-/unixify-1.0.0.tgz#3a641c8c2ffbce4da683a5c70f03a462940c2090"
+  integrity sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg==
+  dependencies:
+    normalize-path "^2.1.1"
+
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
@@ -9768,6 +9828,11 @@ validate-npm-package-name@^3.0.0:
   integrity sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==
   dependencies:
     builtins "^1.0.3"
+
+value-or-promise@^1.0.12:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/value-or-promise/-/value-or-promise-1.0.12.tgz#0e5abfeec70148c78460a849f6b003ea7986f15c"
+  integrity sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q==
 
 vary@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
**Summary**

The schema files copied from the server side code uses `extend type`, which is interpreted as a client schema extension so that relay don't generate a query string for extended fields such as `myViewHistory`.

To solve this issue, we introduced `@graphql-tools` to merge the server schema files into single schema file and use it for the client schema.

With the schema merge, the schema string like

```
type Foo {
    foo(): String!
}

extend type Foo {
    bar(): String!
}
```

is merged to

```
type Foo {
    foo(): String!
    bar(): String!
}
```

**Test**

- expo

**Issue**

- N/A