### PR TITLE
[expo] add SectionList to HomeTab

### DIFF
--- a/expo/.eslintrc.js
+++ b/expo/.eslintrc.js
@@ -11,7 +11,8 @@ module.exports = {
         project: './tsconfig.json'
       },
       rules: {
-        'no-array-constructor': 'off'
+        'no-array-constructor': 'off',
+        'no-console': 'error'
       }
     }
   ]

--- a/expo/assets/translations.json
+++ b/expo/assets/translations.json
@@ -5,6 +5,27 @@
   "I agree": {
     "ja": "同意します"
   },
+  "Pending Payments": {
+    "ja": "入金待ち"
+  },
+  "Payment Due": {
+    "ja": "入金締切"
+  },
+  "# of Tickets": {
+    "ja": "チケット数"
+  },
+  "Next Events": {
+    "ja": "次のイベント"
+  },
+  "Open At": {
+    "ja": "開場時間"
+  },
+  "Start At": {
+    "ja": "開演時間"
+  },
+  "Latest Posts": {
+    "ja": "最新の投稿"
+  },
   "Artists": {
     "ja": "アーティスト"
   },

--- a/expo/features/common/components/CalendarDateIcon.tsx
+++ b/expo/features/common/components/CalendarDateIcon.tsx
@@ -1,0 +1,50 @@
+import Text from '@hpapp/features/common/components/Text';
+import { View, StyleSheet } from 'react-native';
+
+export default function CalendarDateIcon({ date }: { date: Date | undefined | null }) {
+  return (
+    <View style={styles.column}>
+      {date ? (
+        <>
+          <Text style={styles.textMonth}>{date?.getMonth() + 1}月</Text>
+          <Text style={styles.textDate}>{date.getDate()}</Text>
+        </>
+      ) : (
+        <Text style={styles.textDateUndefined}>-</Text>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  column: {
+    width: 40,
+    height: 40,
+    flexDirection: 'column',
+    borderRadius: 8,
+    borderWidth: 2,
+    borderColor: '#cacaca',
+    alignItems: 'center',
+    justifyContent: 'center'
+  },
+  textDateUndefined: {
+    fontWeight: 'bold',
+    fontSize: 20,
+    textAlign: 'center',
+    width: '100%'
+  },
+  textMonth: {
+    marginTop: 2,
+    fontSize: 9,
+    fontWeight: 'bold',
+    textAlign: 'center',
+    width: '100%'
+  },
+  textDate: {
+    marginTop: -4,
+    fontWeight: 'bold',
+    fontSize: 20,
+    textAlign: 'center',
+    width: '100%'
+  }
+});

--- a/expo/features/common/components/Text.tsx
+++ b/expo/features/common/components/Text.tsx
@@ -1,15 +1,13 @@
-import { FontSize, Fonts } from '@hpapp/features/common/constants';
+import { FontSize } from '@hpapp/features/common/constants';
 import { useColor } from '@hpapp/features/settings/context/theme';
 import React from 'react';
 import { Text as Text_, StyleSheet } from 'react-native';
 
 const styles = StyleSheet.create({
   text: {
-    fontFamily: Fonts.Main,
     fontSize: FontSize.Medium
   },
   textBold: {
-    fontFamily: Fonts.Bold,
     fontSize: FontSize.Medium
   }
 });

--- a/expo/features/common/components/list/SectionListSectionHeader.tsx
+++ b/expo/features/common/components/list/SectionListSectionHeader.tsx
@@ -1,0 +1,43 @@
+import Text from '@hpapp/features/common/components/Text';
+import { FontSize, Spacing } from '@hpapp/features/common/constants';
+import { useColor } from '@hpapp/features/settings/context/theme';
+import { View, StyleSheet } from 'react-native';
+
+export default function SectionListSectionHeader({ children }: { children: string }) {
+  const [color, constrastColor] = useColor('secondary');
+  return (
+    <View
+      style={{
+        flexDirection: 'row'
+      }}
+    >
+      <View
+        style={[
+          styles.container,
+          {
+            backgroundColor: color,
+            borderColor: color
+          }
+        ]}
+      >
+        <Text style={[styles.text, { color: constrastColor }]}>{children}</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    paddingLeft: Spacing.Small,
+    paddingRight: Spacing.Small,
+    paddingTop: Spacing.XXSmall,
+    paddingBottom: Spacing.XXSmall,
+    margin: Spacing.XSmall,
+    borderWidth: 1,
+    borderRadius: 8
+  },
+  text: {
+    fontSize: FontSize.Small,
+    fontWeight: 'bold'
+  }
+});

--- a/expo/features/feed/__generated__/FeedListItemFragment.graphql.ts
+++ b/expo/features/feed/__generated__/FeedListItemFragment.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6b957c316d972596acb53c00802c2df4>>
+ * @generated SignedSource<<f5595f200f7a1e3cac794cff1447652a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,10 +17,15 @@ export type FeedListItemFragment$data = {
   readonly imageURL: string | null;
   readonly ownerMember: {
     readonly id: string;
+    readonly key: string;
   } | null;
   readonly postAt: string;
   readonly sourceID: number;
   readonly sourceURL: string;
+  readonly taggedMembers: ReadonlyArray<{
+    readonly id: string;
+    readonly key: string;
+  }> | null;
   readonly title: string;
   readonly " $fragmentSpreads": FragmentRefs<"FeedListItemViewHistoryIconFragment">;
   readonly " $fragmentType": "FeedListItemFragment";
@@ -37,7 +42,17 @@ var v0 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-};
+},
+v1 = [
+  (v0/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "key",
+    "storageKey": null
+  }
+];
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -94,9 +109,17 @@ return {
       "kind": "LinkedField",
       "name": "ownerMember",
       "plural": false,
-      "selections": [
-        (v0/*: any*/)
-      ],
+      "selections": (v1/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "HPMember",
+      "kind": "LinkedField",
+      "name": "taggedMembers",
+      "plural": true,
+      "selections": (v1/*: any*/),
       "storageKey": null
     },
     {
@@ -110,6 +133,6 @@ return {
 };
 })();
 
-(node as any).hash = "6b375a3caabd3a62a7f967e8409b71e5";
+(node as any).hash = "d54fab5bf167a458740ef1e842ea1ca5";
 
 export default node;

--- a/expo/features/feed/__generated__/useFeedFeedQuery.graphql.ts
+++ b/expo/features/feed/__generated__/useFeedFeedQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5c48c763d7884161d7c9e69ae47ddb5d>>
+ * @generated SignedSource<<36fabcd9104b2325d880a87aa1cee387>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,19 +17,19 @@ export type HPFeedQueryParamsInput = {
   minPostAt?: string | null;
   useMemberTaggings?: boolean | null;
 };
-export type FeedQuery$variables = {
+export type useFeedFeedQuery$variables = {
   after?: any | null;
   first?: number | null;
   params: HPFeedQueryParamsInput;
 };
-export type FeedQuery$data = {
+export type useFeedFeedQuery$data = {
   readonly helloproject: {
-    readonly " $fragmentSpreads": FragmentRefs<"FeedQuery_helloproject_query_feed">;
+    readonly " $fragmentSpreads": FragmentRefs<"useFeedQuery_helloproject_query_feed">;
   };
 };
-export type FeedQuery = {
-  response: FeedQuery$data;
-  variables: FeedQuery$variables;
+export type useFeedFeedQuery = {
+  response: useFeedFeedQuery$data;
+  variables: useFeedFeedQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -91,7 +91,7 @@ return {
     ],
     "kind": "Fragment",
     "metadata": null,
-    "name": "FeedQuery",
+    "name": "useFeedFeedQuery",
     "selections": [
       {
         "alias": null,
@@ -104,7 +104,7 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "FeedQuery_helloproject_query_feed"
+            "name": "useFeedQuery_helloproject_query_feed"
           }
         ],
         "storageKey": null
@@ -121,7 +121,7 @@ return {
       (v0/*: any*/)
     ],
     "kind": "Operation",
-    "name": "FeedQuery",
+    "name": "useFeedFeedQuery",
     "selections": [
       {
         "alias": null,
@@ -303,16 +303,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "028ae092aa02f43bb343d4f5ca6f6650",
+    "cacheID": "8e271ec0e07a4452a06a0521ffd59b4d",
     "id": null,
     "metadata": {},
-    "name": "FeedQuery",
+    "name": "useFeedFeedQuery",
     "operationKind": "query",
-    "text": "query FeedQuery(\n  $params: HPFeedQueryParamsInput!\n  $first: Int\n  $after: Cursor\n) {\n  helloproject {\n    ...FeedQuery_helloproject_query_feed\n    id\n  }\n}\n\nfragment FeedListItemFragment on HPFeedItem {\n  id\n  title\n  sourceID\n  sourceURL\n  imageURL\n  assetType\n  postAt\n  ownerMember {\n    id\n    key\n  }\n  taggedMembers {\n    id\n    key\n  }\n  ...FeedListItemViewHistoryIconFragment\n}\n\nfragment FeedListItemViewHistoryIconFragment on HPFeedItem {\n  myViewHistory {\n    id\n    isFavorite\n  }\n}\n\nfragment FeedQuery_helloproject_query_feed on HelloProjectQuery {\n  feed(params: $params, first: $first, after: $after) {\n    edges {\n      node {\n        id\n        ...FeedListItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query useFeedFeedQuery(\n  $params: HPFeedQueryParamsInput!\n  $first: Int\n  $after: Cursor\n) {\n  helloproject {\n    ...useFeedQuery_helloproject_query_feed\n    id\n  }\n}\n\nfragment FeedListItemFragment on HPFeedItem {\n  id\n  title\n  sourceID\n  sourceURL\n  imageURL\n  assetType\n  postAt\n  ownerMember {\n    id\n    key\n  }\n  taggedMembers {\n    id\n    key\n  }\n  ...FeedListItemViewHistoryIconFragment\n}\n\nfragment FeedListItemViewHistoryIconFragment on HPFeedItem {\n  myViewHistory {\n    id\n    isFavorite\n  }\n}\n\nfragment useFeedQuery_helloproject_query_feed on HelloProjectQuery {\n  feed(params: $params, first: $first, after: $after) {\n    edges {\n      node {\n        id\n        ...FeedListItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "8109a2525a73d74d21bcd1a9ca57a1dc";
+(node as any).hash = "ca31d7a1c2ed72859f64b0631ff65e83";
 
 export default node;

--- a/expo/features/feed/__generated__/useFeedQueryFragmentQuery.graphql.ts
+++ b/expo/features/feed/__generated__/useFeedQueryFragmentQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2f878c99f341ddd904dcd985839991c2>>
+ * @generated SignedSource<<4cc8299415c0847531ca3ab4a1076020>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,20 +17,20 @@ export type HPFeedQueryParamsInput = {
   minPostAt?: string | null;
   useMemberTaggings?: boolean | null;
 };
-export type FeedQueryFragmentQuery$variables = {
+export type useFeedQueryFragmentQuery$variables = {
   after?: any | null;
   first?: number | null;
   id: string;
   params: HPFeedQueryParamsInput;
 };
-export type FeedQueryFragmentQuery$data = {
+export type useFeedQueryFragmentQuery$data = {
   readonly node: {
-    readonly " $fragmentSpreads": FragmentRefs<"FeedQuery_helloproject_query_feed">;
+    readonly " $fragmentSpreads": FragmentRefs<"useFeedQuery_helloproject_query_feed">;
   } | null;
 };
-export type FeedQueryFragmentQuery = {
-  response: FeedQueryFragmentQuery$data;
-  variables: FeedQueryFragmentQuery$variables;
+export type useFeedQueryFragmentQuery = {
+  response: useFeedQueryFragmentQuery$data;
+  variables: useFeedQueryFragmentQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -112,7 +112,7 @@ return {
     ],
     "kind": "Fragment",
     "metadata": null,
-    "name": "FeedQueryFragmentQuery",
+    "name": "useFeedQueryFragmentQuery",
     "selections": [
       {
         "alias": null,
@@ -125,7 +125,7 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "FeedQuery_helloproject_query_feed"
+            "name": "useFeedQuery_helloproject_query_feed"
           }
         ],
         "storageKey": null
@@ -143,7 +143,7 @@ return {
       (v2/*: any*/)
     ],
     "kind": "Operation",
-    "name": "FeedQueryFragmentQuery",
+    "name": "useFeedQueryFragmentQuery",
     "selections": [
       {
         "alias": null,
@@ -327,16 +327,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a8f519b1100c76cfd1ed2bbe373ec322",
+    "cacheID": "230ea689d4104853ac886d6b21abd598",
     "id": null,
     "metadata": {},
-    "name": "FeedQueryFragmentQuery",
+    "name": "useFeedQueryFragmentQuery",
     "operationKind": "query",
-    "text": "query FeedQueryFragmentQuery(\n  $after: Cursor\n  $first: Int\n  $params: HPFeedQueryParamsInput!\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...FeedQuery_helloproject_query_feed\n    id\n  }\n}\n\nfragment FeedListItemFragment on HPFeedItem {\n  id\n  title\n  sourceID\n  sourceURL\n  imageURL\n  assetType\n  postAt\n  ownerMember {\n    id\n    key\n  }\n  taggedMembers {\n    id\n    key\n  }\n  ...FeedListItemViewHistoryIconFragment\n}\n\nfragment FeedListItemViewHistoryIconFragment on HPFeedItem {\n  myViewHistory {\n    id\n    isFavorite\n  }\n}\n\nfragment FeedQuery_helloproject_query_feed on HelloProjectQuery {\n  feed(params: $params, first: $first, after: $after) {\n    edges {\n      node {\n        id\n        ...FeedListItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
+    "text": "query useFeedQueryFragmentQuery(\n  $after: Cursor\n  $first: Int\n  $params: HPFeedQueryParamsInput!\n  $id: ID!\n) {\n  node(id: $id) {\n    __typename\n    ...useFeedQuery_helloproject_query_feed\n    id\n  }\n}\n\nfragment FeedListItemFragment on HPFeedItem {\n  id\n  title\n  sourceID\n  sourceURL\n  imageURL\n  assetType\n  postAt\n  ownerMember {\n    id\n    key\n  }\n  taggedMembers {\n    id\n    key\n  }\n  ...FeedListItemViewHistoryIconFragment\n}\n\nfragment FeedListItemViewHistoryIconFragment on HPFeedItem {\n  myViewHistory {\n    id\n    isFavorite\n  }\n}\n\nfragment useFeedQuery_helloproject_query_feed on HelloProjectQuery {\n  feed(params: $params, first: $first, after: $after) {\n    edges {\n      node {\n        id\n        ...FeedListItemFragment\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n"
   }
 };
 })();
 
-(node as any).hash = "5b8c49515bf5d614e6023c2240cb9dfa";
+(node as any).hash = "4310868218d058d88bb4e8e7488033d1";
 
 export default node;

--- a/expo/features/feed/__generated__/useFeedQuery_helloproject_query_feed.graphql.ts
+++ b/expo/features/feed/__generated__/useFeedQuery_helloproject_query_feed.graphql.ts
@@ -1,0 +1,177 @@
+/**
+ * @generated SignedSource<<942073a66c3318958fbabcb5998a571e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment, RefetchableFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type useFeedQuery_helloproject_query_feed$data = {
+  readonly feed: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly id: string;
+        readonly " $fragmentSpreads": FragmentRefs<"FeedListItemFragment">;
+      } | null;
+    } | null> | null;
+  } | null;
+  readonly id: string;
+  readonly " $fragmentType": "useFeedQuery_helloproject_query_feed";
+};
+export type useFeedQuery_helloproject_query_feed$key = {
+  readonly " $data"?: useFeedQuery_helloproject_query_feed$data;
+  readonly " $fragmentSpreads": FragmentRefs<"useFeedQuery_helloproject_query_feed">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  "feed"
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [
+    {
+      "kind": "RootArgument",
+      "name": "after"
+    },
+    {
+      "kind": "RootArgument",
+      "name": "first"
+    },
+    {
+      "kind": "RootArgument",
+      "name": "params"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": {
+    "connection": [
+      {
+        "count": "first",
+        "cursor": "after",
+        "direction": "forward",
+        "path": (v0/*: any*/)
+      }
+    ],
+    "refetch": {
+      "connection": {
+        "forward": {
+          "count": "first",
+          "cursor": "after"
+        },
+        "backward": null,
+        "path": (v0/*: any*/)
+      },
+      "fragmentPathInResult": [
+        "node"
+      ],
+      "operation": require('./useFeedQueryFragmentQuery.graphql'),
+      "identifierField": "id"
+    }
+  },
+  "name": "useFeedQuery_helloproject_query_feed",
+  "selections": [
+    {
+      "alias": "feed",
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "params",
+          "variableName": "params"
+        }
+      ],
+      "concreteType": "HPFeedItemConnection",
+      "kind": "LinkedField",
+      "name": "__FeedQuery_helloproject_query_feed_connection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "HPFeedItemEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "HPFeedItem",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v1/*: any*/),
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "FeedListItemFragment"
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "__typename",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "cursor",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PageInfo",
+          "kind": "LinkedField",
+          "name": "pageInfo",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "endCursor",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "hasNextPage",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    (v1/*: any*/)
+  ],
+  "type": "HelloProjectQuery",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "4310868218d058d88bb4e8e7488033d1";
+
+export default node;

--- a/expo/features/feed/useFeed.ts
+++ b/expo/features/feed/useFeed.ts
@@ -1,0 +1,59 @@
+import { FeedQuery, HPAssetType } from '@hpapp/features/feed/__generated__/FeedQuery.graphql';
+import { FeedQueryFragmentQuery } from '@hpapp/features/feed/__generated__/FeedQueryFragmentQuery.graphql';
+import { FeedQuery_helloproject_query_feed$key } from '@hpapp/features/feed/__generated__/FeedQuery_helloproject_query_feed.graphql';
+import * as date from '@hpapp/foundation/date';
+import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
+
+const useFeedQueryGraphQL = graphql`
+  query useFeedFeedQuery($params: HPFeedQueryParamsInput!, $first: Int, $after: Cursor) {
+    helloproject {
+      ...useFeedQuery_helloproject_query_feed
+    }
+  }
+`;
+
+const FeedQueryFragmentGraphQL = graphql`
+  fragment useFeedQuery_helloproject_query_feed on HelloProjectQuery
+  @refetchable(queryName: "useFeedQueryFragmentQuery") {
+    feed(params: $params, first: $first, after: $after) @connection(key: "FeedQuery_helloproject_query_feed") {
+      edges {
+        node {
+          id
+          ...FeedListItemFragment
+        }
+      }
+    }
+  }
+`;
+
+export type FeedProps = {
+  assetTypes: HPAssetType[];
+  numFetch: number;
+  memberIds: string[];
+  useMemberTaggings: boolean;
+};
+
+const minPostAtForTaggedFeed = 3 * date.N_DAYS;
+
+export default function useFeed({ numFetch, memberIds, assetTypes, useMemberTaggings }: FeedProps) {
+  // TODO: #28 Revisit Tagged Feed Feature
+  // We use 30 days window when fetching tagged feed to get the items without timeout.
+  // but this prevents users from loading items older than 30 days.
+  const minPostAt = useMemberTaggings
+    ? new Date(date.getToday().getTime() - minPostAtForTaggedFeed).toISOString()
+    : null;
+  const data = useLazyLoadQuery<FeedQuery>(useFeedQueryGraphQL, {
+    first: numFetch,
+    params: {
+      assetTypes,
+      memberIDs: memberIds,
+      useMemberTaggings,
+      minPostAt
+    }
+  });
+  const fragment = usePaginationFragment<FeedQueryFragmentQuery, FeedQuery_helloproject_query_feed$key>(
+    FeedQueryFragmentGraphQL,
+    data.helloproject
+  );
+  return fragment;
+}

--- a/expo/features/home/HomeScreen.tsx
+++ b/expo/features/home/HomeScreen.tsx
@@ -1,11 +1,11 @@
 import ArtistsTab from '@hpapp/features/artist/ArtistsTab';
-import { Fonts } from '@hpapp/features/common/constants';
 import EventsTab from '@hpapp/features/home/Events';
 import GoodsTab from '@hpapp/features/home/GoodsTab';
 import HomeTab from '@hpapp/features/home/HomeTab';
 import { defineScreen, useNavigationOption } from '@hpapp/features/root/protected/stack';
 import SettingsTab from '@hpapp/features/settings/SettingsTab';
 import { useColor } from '@hpapp/features/settings/context/theme';
+import { UPFCProvider } from '@hpapp/features/upfc/context';
 import { t } from '@hpapp/system/i18n';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import Ionicons from 'react-native-vector-icons/Ionicons';
@@ -56,32 +56,33 @@ export default defineScreen('/', function () {
   useNavigationOption({ headerShown: false });
   const [primary, contrast] = useColor('primary');
   return (
-    <Tab.Navigator
-      screenOptions={({ route }) => {
-        return {
-          headerStyle: {
-            backgroundColor: primary
-          },
-          headerTintColor: contrast,
-          headerTitleStyle: {
-            fontWeight: 'bold',
-            fontFamily: Fonts.Main
-          }
-        };
-      }}
-    >
-      {Tabs.map((tab) => {
-        return (
-          <Tab.Screen
-            key={tab.name}
-            name={t(tab.name)}
-            component={tab.component}
-            options={{
-              tabBarIcon: getTabBarIconFn(tab.icon)
-            }}
-          />
-        );
-      })}
-    </Tab.Navigator>
+    <UPFCProvider>
+      <Tab.Navigator
+        screenOptions={({ route }) => {
+          return {
+            headerStyle: {
+              backgroundColor: primary
+            },
+            headerTintColor: contrast,
+            headerTitleStyle: {
+              fontWeight: 'bold'
+            }
+          };
+        }}
+      >
+        {Tabs.map((tab) => {
+          return (
+            <Tab.Screen
+              key={tab.name}
+              name={t(tab.name)}
+              component={tab.component}
+              options={{
+                tabBarIcon: getTabBarIconFn(tab.icon)
+              }}
+            />
+          );
+        })}
+      </Tab.Navigator>
+    </UPFCProvider>
   );
 });

--- a/expo/features/home/HomeTab.tsx
+++ b/expo/features/home/HomeTab.tsx
@@ -1,13 +1,5 @@
-import HomeTabFeed from '@hpapp/features/home/HomeTabFeed';
-import { UPFCProvider } from '@hpapp/features/upfc/context';
-import { View } from 'react-native';
+import HomeTabSectionList from '@hpapp/features/home/HomeTabSectionList';
 
 export default function HomeTab() {
-  return (
-    <View style={{ flex: 1 }}>
-      <UPFCProvider>
-        <HomeTabFeed />
-      </UPFCProvider>
-    </View>
-  );
+  return <HomeTabSectionList />;
 }

--- a/expo/features/home/HomeTabSectionList.tsx
+++ b/expo/features/home/HomeTabSectionList.tsx
@@ -1,0 +1,46 @@
+import useFeed from '@hpapp/features/feed/useFeed';
+import { HomeTabSection } from '@hpapp/features/home/types';
+import { useMe } from '@hpapp/features/root/protected/context';
+import { useColor } from '@hpapp/features/settings/context/theme';
+import useLocalUserConfig from '@hpapp/features/settings/context/useLocalUserConfig';
+import { useUPFC } from '@hpapp/features/upfc/context';
+import FeedSection from '@hpapp/features/upfc/home/FeedSection';
+import NextEventsSection from '@hpapp/features/upfc/home/NextEventsSection';
+import PendingPaymentsSection from '@hpapp/features/upfc/home/PendingPaymentsSection';
+import { useMemo } from 'react';
+import { SectionList } from 'react-native';
+
+export default function HomeTabSectionList() {
+  const [color] = useColor('primary');
+  const [config] = useLocalUserConfig();
+  const followings = useMe()
+    .followings.filter((f) => f.type !== 'unfollow')
+    .map((f) => f.memberId);
+  const numFetch = followings.length > 10 ? followings.length + 10 : 15;
+  const upfc = useUPFC();
+  const feed = useFeed({
+    numFetch,
+    assetTypes: ['ameblo', 'instagram', 'tiktok', 'twitter'],
+    memberIds: followings,
+    useMemberTaggings: config?.feedUseMemberTaggings ?? false
+  });
+  const sections: HomeTabSection<unknown>[] = useMemo(() => {
+    return [
+      new PendingPaymentsSection(color, upfc.data ?? []),
+      new NextEventsSection(color, upfc.data ?? []),
+      new FeedSection((feed.data.feed?.edges ?? []).filter((edge) => edge?.node != null).map((edge) => edge!.node!))
+    ];
+  }, [upfc.data, feed]);
+  return (
+    <SectionList
+      sections={sections}
+      keyExtractor={(item, index) => `hometabsectionlist-${index}`}
+      renderSectionHeader={({ section }) => {
+        return section.renderSectionHeader();
+      }}
+      renderItem={(o) => {
+        return o.section.renderListItem(o);
+      }}
+    />
+  );
+}

--- a/expo/features/home/types.ts
+++ b/expo/features/home/types.ts
@@ -1,0 +1,9 @@
+interface HomeTabSection<T> {
+  renderSectionHeader(): JSX.Element;
+  // DO NOT use renderItem as it's reservered by SectionList.
+  // we have to use renderItem={(o) => { o.section.renderListItem(o)}} to use the bound members.
+  renderListItem(v: { item: T; index: number }): JSX.Element;
+  data: T[];
+}
+
+export { HomeTabSection };

--- a/expo/features/root/protected/context/__generated__/contextServiceRootQuery.graphql.ts
+++ b/expo/features/root/protected/context/__generated__/contextServiceRootQuery.graphql.ts
@@ -1,0 +1,358 @@
+/**
+ * @generated SignedSource<<43b5c98e6f826baab60fb6c5d531496d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type contextServiceRootQuery$variables = {};
+export type contextServiceRootQuery$data = {
+  readonly helloproject: {
+    readonly " $fragmentSpreads": FragmentRefs<"helloprojectFragment">;
+  };
+  readonly me: {
+    readonly " $fragmentSpreads": FragmentRefs<"meFragment">;
+  };
+};
+export type contextServiceRootQuery = {
+  response: contextServiceRootQuery$data;
+  variables: contextServiceRootQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "key",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "thumbnailURL",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "contextServiceRootQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "HelloProjectQuery",
+        "kind": "LinkedField",
+        "name": "helloproject",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "helloprojectFragment"
+          }
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "MeQuery",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "meFragment"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "contextServiceRootQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "HelloProjectQuery",
+        "kind": "LinkedField",
+        "name": "helloproject",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "HPArtist",
+            "kind": "LinkedField",
+            "name": "artists",
+            "plural": true,
+            "selections": [
+              (v0/*: any*/),
+              (v1/*: any*/),
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "HPMember",
+                "kind": "LinkedField",
+                "name": "members",
+                "plural": true,
+                "selections": [
+                  (v0/*: any*/),
+                  (v1/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "artistKey",
+                    "storageKey": null
+                  },
+                  (v2/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "nameKana",
+                    "storageKey": null
+                  },
+                  (v3/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "dateOfBirth",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "bloodType",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "joinAt",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "graduateAt",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v0/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "MeQuery",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v0/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "username",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "clientId",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "clientName",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "HPFollow",
+            "kind": "LinkedField",
+            "name": "followings",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "type",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "HPMember",
+                "kind": "LinkedField",
+                "name": "member",
+                "plural": false,
+                "selections": [
+                  (v0/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v0/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "HPSortHistoryConnection",
+            "kind": "LinkedField",
+            "name": "sortHistories",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "HPSortHistoryEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "HPSortHistory",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v0/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "createdAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "HPSortResult",
+                        "kind": "LinkedField",
+                        "name": "sortResult",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "HPSortResultRecord",
+                            "kind": "LinkedField",
+                            "name": "records",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "artistId",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "memberId",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "memberKey",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "sortHistories(first:1)"
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "874b31bff725b79b9c9375a88379aef8",
+    "id": null,
+    "metadata": {},
+    "name": "contextServiceRootQuery",
+    "operationKind": "query",
+    "text": "query contextServiceRootQuery {\n  helloproject {\n    ...helloprojectFragment\n    id\n  }\n  me {\n    ...meFragment\n    id\n  }\n}\n\nfragment helloprojectFragment on HelloProjectQuery {\n  artists {\n    id\n    key\n    name\n    thumbnailURL\n    members {\n      id\n      key\n      artistKey\n      name\n      nameKana\n      thumbnailURL\n      dateOfBirth\n      bloodType\n      joinAt\n      graduateAt\n    }\n  }\n}\n\nfragment meFragment on MeQuery {\n  id\n  username\n  clientId\n  clientName\n  followings {\n    type\n    member {\n      id\n    }\n    id\n  }\n  sortHistories(first: 1) {\n    edges {\n      node {\n        id\n        createdAt\n        sortResult {\n          records {\n            artistId\n            memberId\n            memberKey\n          }\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "cb190d39af1e40da15472e94a43eaf20";
+
+export default node;

--- a/expo/features/root/protected/context/index.tsx
+++ b/expo/features/root/protected/context/index.tsx
@@ -11,7 +11,7 @@ import { Suspense, createContext, useContext, useEffect, useMemo } from 'react';
 import { graphql, useQueryLoader, usePreloadedQuery, PreloadedQuery } from 'react-relay';
 
 const servicerootQueryGraphQL = graphql`
-  query servicerootQuery {
+  query contextServiceRootQuery {
     helloproject {
       ...helloprojectFragment
     }

--- a/expo/features/settings/devonly/DevOnlySettingsListItem.tsx
+++ b/expo/features/settings/devonly/DevOnlySettingsListItem.tsx
@@ -14,7 +14,8 @@ export default function DevOnlySettingsListItem({
     <>
       <ListItem
         onPress={() => {
-          // console output so that developer can copy on their terminal.
+          // intentional console output so that developer can copy on their terminal.
+          // eslint-disable-next-line no-console
           console.log('Settings', name, ':', value);
         }}
       >

--- a/expo/features/upfc/context/index.tsx
+++ b/expo/features/upfc/context/index.tsx
@@ -9,8 +9,8 @@ import React, { createContext, useContext, useMemo } from 'react';
 
 export interface UPFCContext {
   isConfigured: boolean;
-  data: EventApplicationTickets[] | null;
   isLoading: boolean;
+  data: EventApplicationTickets[] | null;
   reload: () => void;
 }
 

--- a/expo/features/upfc/home/FeedSection.tsx
+++ b/expo/features/upfc/home/FeedSection.tsx
@@ -1,0 +1,25 @@
+import SectionListSectionHeader from '@hpapp/features/common/components/list/SectionListSectionHeader';
+import FeedListItem from '@hpapp/features/feed/FeedListItem';
+import useFeed from '@hpapp/features/feed/useFeed';
+import { HomeTabSection } from '@hpapp/features/home/types';
+import { t } from '@hpapp/system/i18n';
+
+type FeedNode = NonNullable<
+  NonNullable<NonNullable<NonNullable<ReturnType<typeof useFeed>['data']['feed']>['edges']>[number]>['node']
+>;
+
+export default class FeedSection implements HomeTabSection<FeedNode> {
+  public readonly data: FeedNode[];
+
+  constructor(data: FeedNode[]) {
+    this.data = data;
+  }
+
+  renderSectionHeader() {
+    return <SectionListSectionHeader>{t('Latest Posts')}</SectionListSectionHeader>;
+  }
+
+  renderListItem({ item, index }: { item: FeedNode; index: number }) {
+    return <FeedListItem data={item} />;
+  }
+}

--- a/expo/features/upfc/home/NextEventsSection.tsx
+++ b/expo/features/upfc/home/NextEventsSection.tsx
@@ -1,0 +1,108 @@
+import CalendarDateIcon from '@hpapp/features/common/components/CalendarDateIcon';
+import Text from '@hpapp/features/common/components/Text';
+import ListItem from '@hpapp/features/common/components/list/ListItem';
+import SectionListSectionHeader from '@hpapp/features/common/components/list/SectionListSectionHeader';
+import { FontSize, IconSize, Spacing } from '@hpapp/features/common/constants';
+import { HomeTabSection } from '@hpapp/features/home/types';
+import { EventApplicationTickets, EventTicket } from '@hpapp/features/upfc/scraper';
+import * as date from '@hpapp/foundation/date';
+import { t } from '@hpapp/system/i18n';
+import { Icon } from '@rneui/base';
+import { View, StyleSheet } from 'react-native';
+
+type ApplicationEventTicket = EventTicket & {
+  name: string;
+};
+
+export default class NextEventsSection implements HomeTabSection<ApplicationEventTicket> {
+  private primaryColor: string;
+  public readonly data: ApplicationEventTicket[];
+
+  constructor(primaryColor: string, data: EventApplicationTickets[]) {
+    this.primaryColor = primaryColor;
+    const now = new Date();
+    // convert the mapping from application -> tickets to ticket -> application to sort by ticket start date,
+    // then recompose ApplicationEventTicket
+    this.data = data
+      .map((event) => {
+        return event.tickets.map((t) => {
+          return { ...t, name: event.name };
+        });
+      })
+      .flat()
+      .filter((t) => {
+        if (t.status !== '入金済') {
+          return false; // not eligible to join
+        }
+        if (now.getTime() > t.startAt.getTime()) {
+          return false; // already started
+        }
+        return true;
+      })
+      .sort((a, b) => {
+        return a.startAt.getTime() - b.startAt.getTime();
+      });
+  }
+
+  renderSectionHeader() {
+    if (this.data.length > 0) {
+      return <SectionListSectionHeader>{t('Next Events')}</SectionListSectionHeader>;
+    }
+    return <></>;
+  }
+
+  renderListItem({ item, index }: { item: ApplicationEventTicket; index: number }) {
+    if (index > 1) {
+      return <></>;
+    }
+    const venue = item.venue ?? '';
+    return (
+      <ListItem
+        containerStyle={styles.listItem}
+        leftContent={<CalendarDateIcon date={item.startAt} />}
+        rightContent={<Icon name="place" size={IconSize.Medium} color={this.primaryColor} />}
+        onPress={() => {}}
+      >
+        <View style={styles.listItemCenter}>
+          <View>
+            <Text style={styles.listItemCenterText} numberOfLines={1}>
+              {item.name}
+            </Text>
+            <Text style={styles.listItemCenterText} numberOfLines={1}>
+              {venue}
+            </Text>
+            <View style={styles.listItemCenterTextFooterRow}>
+              {item.openAt && (
+                <Text style={[styles.listItemCenterText, styles.listItemCenterTextColumn]}>
+                  {t('Open At')}: {date.toTimeString(item.openAt)}
+                </Text>
+              )}
+              <Text style={[styles.listItemCenterText, styles.listItemCenterTextColumn]}>
+                {t('Start At')}: {date.toTimeString(item.startAt)}
+              </Text>
+            </View>
+          </View>
+        </View>
+      </ListItem>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  listItem: {
+    paddingLeft: Spacing.XSmall,
+    paddingRight: Spacing.XSmall
+  },
+  listItemCenter: {
+    padding: Spacing.XXSmall
+  },
+  listItemCenterText: {
+    fontSize: FontSize.Small
+  },
+  listItemCenterTextColumn: {
+    marginRight: Spacing.Large
+  },
+  listItemCenterTextFooterRow: {
+    flexDirection: 'row'
+  }
+});

--- a/expo/features/upfc/home/PendingPaymentsSection.tsx
+++ b/expo/features/upfc/home/PendingPaymentsSection.tsx
@@ -1,0 +1,97 @@
+import CalendarDateIcon from '@hpapp/features/common/components/CalendarDateIcon';
+import Text from '@hpapp/features/common/components/Text';
+import ListItem from '@hpapp/features/common/components/list/ListItem';
+import SectionListSectionHeader from '@hpapp/features/common/components/list/SectionListSectionHeader';
+import { FontSize, IconSize, Spacing } from '@hpapp/features/common/constants';
+import { HomeTabSection } from '@hpapp/features/home/types';
+import { EventApplicationTickets } from '@hpapp/features/upfc/scraper';
+import * as date from '@hpapp/foundation/date';
+import { t } from '@hpapp/system/i18n';
+import { Icon } from '@rneui/base';
+import { View, StyleSheet } from 'react-native';
+
+export default class PendingPaymentsSection implements HomeTabSection<EventApplicationTickets> {
+  private primaryColor: string;
+  public readonly data: EventApplicationTickets[];
+
+  constructor(primaryColor: string, data: EventApplicationTickets[]) {
+    this.primaryColor = primaryColor;
+    const now = new Date();
+    // take only events with pending payment tickets
+    this.data = data
+      .map((event) => {
+        const tickets = event.tickets.filter((t) => {
+          if (t.status !== '入金待') {
+            return false;
+          }
+          const pendingDueDate = event.paymentDueDate ?? t.openAt ?? t.startAt;
+          if (now.getTime() > pendingDueDate.getTime()) {
+            return false;
+          }
+          return true;
+        });
+        return {
+          ...event,
+          tickets
+        };
+      })
+      .filter((event) => event.tickets.length > 0);
+  }
+
+  renderSectionHeader() {
+    if (this.data.length > 0) {
+      return <SectionListSectionHeader>{t('Pending Payments')}</SectionListSectionHeader>;
+    }
+    return <></>;
+  }
+
+  renderListItem({ item, index }: { item: EventApplicationTickets; index: number }) {
+    const venue = item.tickets[0].venue ?? '';
+    return (
+      <ListItem
+        containerStyle={styles.listItem}
+        leftContent={<CalendarDateIcon date={item.paymentDueDate} />}
+        rightContent={<Icon name="pay-circle1" type="antdesign" size={IconSize.Medium} color={this.primaryColor} />}
+        onPress={() => {}}
+      >
+        <View style={styles.listItemCenter}>
+          <View>
+            <Text style={styles.listItemCenterText} numberOfLines={1}>
+              {item.name}
+            </Text>
+            <Text style={styles.listItemCenterText} numberOfLines={1}>
+              {venue}
+            </Text>
+            <View style={styles.listItemCenterTextFooterRow}>
+              <Text style={[styles.listItemCenterText, styles.listItemCenterTextColumn]}>
+                {t('Payment Due')}: {date.toDateString(item.paymentDueDate)}
+              </Text>
+              <Text style={[styles.listItemCenterText, styles.listItemCenterTextColumn]}>
+                {t('# of Tickets')}: {item.tickets.length}
+              </Text>
+            </View>
+          </View>
+        </View>
+      </ListItem>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  listItem: {
+    paddingLeft: Spacing.XSmall,
+    paddingRight: Spacing.XSmall
+  },
+  listItemCenter: {
+    padding: Spacing.XXSmall
+  },
+  listItemCenterText: {
+    fontSize: FontSize.Small
+  },
+  listItemCenterTextColumn: {
+    marginRight: Spacing.Large
+  },
+  listItemCenterTextFooterRow: {
+    flexDirection: 'row'
+  }
+});

--- a/expo/foundation/errors.ts
+++ b/expo/foundation/errors.ts
@@ -41,8 +41,10 @@ function renderError(e: unknown) {
   //   it doesn't actually contain any readable sources.
   if (__DEV__) {
     if ((e as Error).stack) {
+      // eslint-disable-next-line no-console
       console.error((e as Error).stack);
     } else {
+      // eslint-disable-next-line no-console
       console.error(e);
     }
   }

--- a/expo/foundation/object.ts
+++ b/expo/foundation/object.ts
@@ -9,4 +9,10 @@ function NormalizeA<T>(v: T | T[]) {
   return [v];
 }
 
-export { In, NormalizeA };
+function filterNulls<T>(v: (T | null | undefined)[]): T[] {
+  return v.filter((vv): vv is T => {
+    return vv !== null && vv !== undefined;
+  });
+}
+
+export { In, NormalizeA, filterNulls };

--- a/expo/system/logging/Console.ts
+++ b/expo/system/logging/Console.ts
@@ -1,9 +1,14 @@
+/* eslint-disable no-console */
 import { LogLevel, LogSink } from '@hpapp/system/logging/types';
 import Constants from 'expo-constants';
 
-const consoleEvents: RegExp[] = (Constants.expoConfig?.extra?.hpapp?.consoleEvents || ['.*']).map((re: string) => {
-  return new RegExp(re);
-});
+const defaultEvents = '.*'; // '.*';
+
+const consoleEvents: RegExp[] = (Constants.expoConfig?.extra?.hpapp?.consoleEvents || [defaultEvents]).map(
+  (re: string) => {
+    return new RegExp(re);
+  }
+);
 
 class Console implements LogSink {
   Log(level: LogLevel, event: string, message: string, data?: Record<string, any> | undefined): void {


### PR DESCRIPTION
**Summary**

We had complex `if/else` statements in v2 SectionList but finally refactored the logic on top of `HomeTabSection<T>` interface.

When we add a new content on HomeTab,

1) defnie a class that implements HomeTabSection<T> 
2) add `data<T>` loadding logic to `HomeTabSectionList` and create an instance of `HomeTabSection<T>`

**Test**

- expo
- yarn test

**Issue**

- N/A