### PR TITLE
[expo] add a note about AppCheck

### DIFF
--- a/docs/expo/development.md
+++ b/docs/expo/development.md
@@ -52,6 +52,10 @@ $ yarn eas secret:create --scope project --name DEV_GOOGLE_SERVICES_JSON --type 
 $ yarn eas secret:create --scope project --name DEV_GOOGLE_SERVICES_INFO_PLIST --type file --value ./config/dev/GoogleService-Info.plist
 ```
 
+### Firebase AppCheck Configuration
+
+If you use Firebase Authentication with AppCheck, you need to configure AppCheck on your firebase project [[ref](https://firebase.google.com/docs/app-check/ios/devicecheck-provider?authuser=0&hl=ja)].
+
 ### secrets.json
 
 `secrets.json` is a file to define application specific configuratons which we don't want to share with others. You need to put it under `./config/$HPAPP_CONFIG_NAME/secrets.json` as well. The file is something like that.

--- a/expo/features/root/context/relay.tsx
+++ b/expo/features/root/context/relay.tsx
@@ -70,7 +70,7 @@ function createEnvironment(config: HttpClientConfig, userToken?: string) {
       return json;
     } catch (err) {
       const benchmark = new Date().getTime() - start.getTime();
-      logging.Error(eventName, 'GraphQL error', {
+      logging.Error(eventName, `GraphQL error: ${(err as Error).message}`, {
         request: {
           body: {
             query: operation.text,


### PR DESCRIPTION
**Summary**

When we build an app with the new package name and it uses Firebase Authentication, it always tries to get AppCheck token in `useFirebaseTokensInHttpHeader()` hook.

The hook can fail when we don't configure AppCheck on our firebase project.

**Test**

- N/A

**Issue**

- N/A