### PR TITLE
[expo] introduce AppConfigModal

### DIFF
--- a/expo/App.tsx
+++ b/expo/App.tsx
@@ -1,29 +1,7 @@
-import FirebaseLoginContainer from '@hpapp/features/auth/firebase/FirebaseLoginContainer';
-import useFirebaseTokensInHttpHeader from '@hpapp/features/auth/firebase/useFirebaseTokensInHttpHeader';
-import LocalLoginContainer from '@hpapp/features/auth/local/LocalLoginContainer';
-import Constants from 'expo-constants';
-
 import Root from './features/root';
 import screens from './generated/Screens';
 
 export default function App() {
-  const headerFn = useFirebaseTokensInHttpHeader();
-  // useLocalLogin when the app use localhost:8080 for GraphQL and useFirebaseLogin is not set.
-  const useLocalLogin =
-    (Constants.expoConfig?.extra?.hpapp?.graphQLEndpoint as string).startsWith('http://localhost:8080/graphql/v3') &&
-    Constants.expoConfig?.extra?.hpapp.useLogalLogin === true;
-  if (useLocalLogin) {
-    return <Root loginContainer={LocalLoginContainer} screens={screens} />;
-  }
   // for production build
-  return (
-    <Root
-      loginContainer={FirebaseLoginContainer}
-      httpClientConfig={{
-        NetworkTimeoutSecond: 60,
-        ExtraHeaderFn: headerFn
-      }}
-      screens={screens}
-    />
-  );
+  return <Root screens={screens} />;
 }

--- a/expo/features/appconfig/AppConfigModal.tsx
+++ b/expo/features/appconfig/AppConfigModal.tsx
@@ -1,0 +1,129 @@
+import { useAppConfigForEdit } from '@hpapp/features/appconfig/useAppConfig';
+import Text from '@hpapp/features/common/components/Text';
+import { FontSize, Spacing } from '@hpapp/features/common/constants';
+import { Button, Dialog, Input, Switch } from '@rneui/themed';
+import { useCallback, useState } from 'react';
+import { StyleSheet, View, Dimensions } from 'react-native';
+
+const deviceHeight = Dimensions.get('window').height;
+
+type AppConfigModalProps = { isVisible: boolean; onClose: () => void };
+
+/**
+ * AppConfigModal shows a modal to configure the application settings.
+ *
+ * @param {boolean} visible - Indicates whether the modal is visible.
+ * @param {() => void} onClose - Callback function to close the modal.
+ */
+export default function AppConfigMoal({ isVisible, onClose }: AppConfigModalProps) {
+  const [appConfig, setAppConfig] = useAppConfigForEdit();
+  const [useLocalAppConfig, setUseLocalAppConfig] = useState(appConfig?.useLocalAppConfig ?? false);
+  const [graphQLEndpoint, setGraphQLEndpoint] = useState(appConfig?.graphQLEndpoint ?? '');
+  const [useLocalAuth, setUseLocalAuth] = useState(appConfig?.useLocalAuth ?? false);
+  const onSave = useCallback(() => {
+    setAppConfig({
+      useLocalAppConfig,
+      graphQLEndpoint,
+      useLocalAuth
+    });
+    onClose();
+  }, [appConfig, setAppConfig]);
+  return (
+    <Dialog isVisible={isVisible} overlayStyle={styles.dialog}>
+      <Dialog.Title>App Configuration</Dialog.Title>
+      <View style={styles.content}>
+        <View style={styles.form}>
+          <View style={[styles.inputGroup, styles.switchContainer]}>
+            <Text style={styles.label}>Use Local AppConfig</Text>
+            <Switch
+              value={useLocalAppConfig}
+              onValueChange={() => {
+                setUseLocalAppConfig(!useLocalAppConfig);
+              }}
+            />
+          </View>
+          <View style={[styles.inputGroup, styles.switchContainer]}>
+            <Text style={styles.label}>Use Local Auth</Text>
+            <Switch
+              value={useLocalAuth}
+              onValueChange={() => {
+                setUseLocalAuth(!useLocalAuth);
+              }}
+            />
+          </View>
+          <View style={!styles.inputGroup}>
+            <Text style={styles.label}>GraphQL Endpoint</Text>
+            <Input
+              disabled={!useLocalAppConfig}
+              keyboardType="url"
+              containerStyle={styles.input}
+              errorStyle={styles.inputError}
+              placeholder="http://localhost:8080/graphql/v3"
+              value={graphQLEndpoint}
+              onChangeText={(text) => {
+                setGraphQLEndpoint(text);
+              }}
+            />
+          </View>
+        </View>
+        <View style={styles.buttonGroup}>
+          <Button type="outline" style={styles.button} onPress={onClose}>
+            Cancel
+          </Button>
+          <Button type="solid" style={styles.button} onPress={onSave}>
+            Save
+          </Button>
+        </View>
+      </View>
+    </Dialog>
+  );
+}
+
+const styles = StyleSheet.create({
+  dialog: {
+    height: deviceHeight - deviceHeight * 0.15,
+    width: '90%'
+  },
+  content: {
+    flex: 1,
+    flexDirection: 'column'
+  },
+  form: {
+    flex: 1,
+    flexGrow: 1
+  },
+  label: {
+    paddingLeft: Spacing.Small,
+    paddingRight: Spacing.Small
+  },
+  default: {
+    fontStyle: 'italic',
+    fontSize: FontSize.XSmall
+  },
+  inputGroup: {
+    marginTop: Spacing.XSmall
+  },
+  switchContainer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: Spacing.Small
+  },
+  input: {},
+  inputError: {},
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  buttonGroup: {
+    marginTop: Spacing.Small,
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'space-evenly'
+  },
+  button: {
+    flexGrow: 1,
+    paddingLeft: Spacing.Small,
+    paddingRight: Spacing.Small
+  }
+});

--- a/expo/features/appconfig/useAppConfig.ts
+++ b/expo/features/appconfig/useAppConfig.ts
@@ -1,0 +1,33 @@
+import { useSettings } from '@hpapp/features/settings/context';
+import { SettingsStore, AsyncStorage } from '@hpapp/system/kvs';
+import Constants from 'expo-constants';
+
+type AppConfig = {
+  readonly useLocalAppConfig: boolean;
+  readonly graphQLEndpoint: string;
+  readonly useLocalAuth: boolean;
+};
+
+const DefaultAppConfig: AppConfig = {
+  useLocalAppConfig: false,
+  graphQLEndpoint: Constants.expoConfig?.extra!.hpapp!.graphQLEndpoint!,
+  useLocalAuth: Constants.expoConfig?.extra!.hpapp!.useLocalAuth!
+};
+
+const AppConfigSettings = SettingsStore.register<AppConfig>('hpapp.appconfig', new AsyncStorage(), {
+  defaultValue: DefaultAppConfig
+});
+
+function useAppConfigForEdit() {
+  return useSettings(AppConfigSettings);
+}
+
+export default function useAppConfig() {
+  const [settings] = useAppConfigForEdit();
+  if (settings?.useLocalAppConfig) {
+    return settings;
+  }
+  return DefaultAppConfig;
+}
+
+export { AppConfigSettings, useAppConfigForEdit, useAppConfig, AppConfig, DefaultAppConfig };

--- a/expo/features/root/GuestRoot.tsx
+++ b/expo/features/root/GuestRoot.tsx
@@ -1,16 +1,15 @@
-import { LoginContainer, User } from '@hpapp/features/auth';
+import useAppConfig from '@hpapp/features/appconfig/useAppConfig';
+import { User } from '@hpapp/features/auth';
+import FirebaseLoginContainer from '@hpapp/features/auth/firebase/FirebaseLoginContainer';
+import LocalLoginContainer from '@hpapp/features/auth/local/LocalLoginContainer';
 import Text from '@hpapp/features/common/components/Text';
 import AppUpdateBanner from '@hpapp/features/root/banner/AppUpdateBanner';
 import { useAssets } from 'expo-asset';
 import { View, StyleSheet, Image } from 'react-native';
 
-export default function GuestRoot({
-  LoginContainer,
-  onAuthenticated
-}: {
-  LoginContainer: LoginContainer;
-  onAuthenticated: (user: User) => void;
-}) {
+export default function GuestRoot({ onAuthenticated }: { onAuthenticated: (user: User) => void }) {
+  const appConfig = useAppConfig();
+  const LoginContainer = appConfig.useLocalAuth ? LocalLoginContainer : FirebaseLoginContainer;
   const [loaded] = useAssets([require('@hpapp/assets/icon.png'), require('@hpapp/assets/splash.png')]);
   if (!loaded) {
     return <></>;

--- a/expo/features/root/TestRoot.tsx
+++ b/expo/features/root/TestRoot.tsx
@@ -1,23 +1,17 @@
+import { AppConfigSettings } from '@hpapp/features/appconfig/useAppConfig';
 import { CurrentUserSettings } from '@hpapp/features/auth';
 import { AnalyticsProvider } from '@hpapp/features/root/context/analytics';
 import { RelayProvider } from '@hpapp/features/root/context/relay';
 import { SettingsProvider } from '@hpapp/features/settings/context';
 import { LocalUserConfigurationSettings } from '@hpapp/features/settings/context/useLocalUserConfig';
 
-const settings = [CurrentUserSettings, LocalUserConfigurationSettings];
+const settings = [CurrentUserSettings, LocalUserConfigurationSettings, AppConfigSettings];
 
 export default function TestRoot({ children }: { children: React.ReactElement }) {
   return (
     <SettingsProvider settings={settings}>
       <AnalyticsProvider>
-        <RelayProvider
-          config={{
-            Endpoint: 'http://localhost:8080/graphql/v3',
-            NetworkTimeoutSecond: 10
-          }}
-        >
-          {children}
-        </RelayProvider>
+        <RelayProvider>{children}</RelayProvider>
       </AnalyticsProvider>
     </SettingsProvider>
   );

--- a/expo/features/root/index.tsx
+++ b/expo/features/root/index.tsx
@@ -1,43 +1,45 @@
-import { CurrentUserSettings, LoginContainer, useCurrentUser } from '@hpapp/features/auth';
+import AppConfigMoal from '@hpapp/features/appconfig/AppConfigModal';
+import { AppConfigSettings } from '@hpapp/features/appconfig/useAppConfig';
+import { CurrentUserSettings, useCurrentUser } from '@hpapp/features/auth';
 import GuestRoot from '@hpapp/features/root/GuestRoot';
 import { Analytics, AnalyticsProvider } from '@hpapp/features/root/context/analytics';
-import { RelayProvider, HttpClientConfig } from '@hpapp/features/root/context/relay';
+import { RelayProvider } from '@hpapp/features/root/context/relay';
 import ProtectedRoot from '@hpapp/features/root/protected/ProtectedRoot';
 import { ScreenList } from '@hpapp/features/root/protected/stack';
 import { SettingsProvider } from '@hpapp/features/settings/context';
 import { AppThemeProvider } from '@hpapp/features/settings/context/theme';
 import { LocalUserConfigurationSettings } from '@hpapp/features/settings/context/useLocalUserConfig';
 import { UPFCSettings } from '@hpapp/features/upfc/settings/useUPFCSettings';
+import { registerDevMenuItems } from 'expo-dev-menu';
+import { useEffect, useState } from 'react';
 
-const settings = [CurrentUserSettings, LocalUserConfigurationSettings, UPFCSettings];
+const settings = [CurrentUserSettings, LocalUserConfigurationSettings, UPFCSettings, AppConfigSettings];
 
-function UserRoot({ LoginContainer, screens }: { LoginContainer: LoginContainer; screens: ScreenList }) {
+function UserRoot({ screens }: { screens: ScreenList }) {
   const [user, setUser] = useCurrentUser();
   if (user) {
     return <ProtectedRoot screens={screens} />;
   }
-  return <GuestRoot LoginContainer={LoginContainer} onAuthenticated={setUser} />;
+  return <GuestRoot onAuthenticated={setUser} />;
 }
 
-export default function Root({
-  loginContainer,
-  analytics,
-  httpClientConfig = {
-    NetworkTimeoutSecond: 60
-  },
-  screens
-}: {
-  loginContainer: LoginContainer;
-  analytics?: Analytics;
-  httpClientConfig?: HttpClientConfig;
-  screens: ScreenList;
-}) {
+export default function Root({ analytics, screens }: { analytics?: Analytics; screens: ScreenList }) {
+  const [showAppConfigModal, setShowAppConfigModal] = useState(false);
+  useEffect(() => {
+    registerDevMenuItems([
+      {
+        name: 'App Config',
+        callback: () => setShowAppConfigModal(!showAppConfigModal)
+      }
+    ]);
+  }, [showAppConfigModal, setShowAppConfigModal]);
   return (
     <SettingsProvider settings={settings}>
       <AppThemeProvider>
         <AnalyticsProvider analytics={analytics}>
-          <RelayProvider config={httpClientConfig}>
-            <UserRoot LoginContainer={loginContainer} screens={screens} />
+          <RelayProvider>
+            <AppConfigMoal isVisible={showAppConfigModal} onClose={() => setShowAppConfigModal(false)} />
+            <UserRoot screens={screens} />
           </RelayProvider>
         </AnalyticsProvider>
       </AppThemeProvider>

--- a/expo/jest.setup.ts
+++ b/expo/jest.setup.ts
@@ -1,5 +1,32 @@
+jest.mock('react-native/Libraries/EventEmitter/NativeEventEmitter');
 jest.mock('@react-native-async-storage/async-storage', () => {
   return require('@react-native-async-storage/async-storage/jest/async-storage-mock');
+});
+
+jest.mock('@react-native-firebase/app-check', () => {
+  return () => ({
+    newReactNativeFirebaseAppCheckProvider: () => {
+      return {
+        configure: jest.fn()
+      };
+    },
+    initializeAppCheck: jest.fn(),
+    getToken: jest.fn()
+  });
+});
+
+jest.mock('expo-constants', () => {
+  return {
+    expoConfig: {
+      extra: {
+        hpapp: {
+          useLocalAppConfig: false,
+          useLocalAuth: true,
+          graphQLEndpoint: 'http://localhost:8080/graphql/v3'
+        }
+      }
+    }
+  };
 });
 
 jest.useFakeTimers();

--- a/expo/package.json
+++ b/expo/package.json
@@ -75,7 +75,7 @@
     "react-native-tab-view": "^3.5.2",
     "react-native-web": "~0.19.10",
     "react-native-webview": "13.8.6",
-    "react-relay": "^15.0.0",
+    "react-relay": "^17.0.0",
     "react-test-renderer": "^18.2.0",
     "ts-node": "^10.9.1"
   },
@@ -87,7 +87,7 @@
     "@testing-library/react-native": "^12.0.1",
     "@types/jest": "^29.5.1",
     "@types/react": "~18.2.79",
-    "@types/react-relay": "^14.1.3",
+    "@types/react-relay": "^16.0.6",
     "babel-plugin-module-resolver": "^5.0.0",
     "babel-plugin-relay": "^15.0.0",
     "eas-cli": "5.4.0",

--- a/expo/yarn.lock
+++ b/expo/yarn.lock
@@ -3079,10 +3079,10 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-relay@^14.1.3":
-  version "14.1.3"
-  resolved "https://registry.yarnpkg.com/@types/react-relay/-/react-relay-14.1.3.tgz#d8a64e816c255910be7c94170e20472cafe5a51f"
-  integrity sha512-tsu+3jN0zeOYKV485fwUy3yMEZWkDVzC2JG0tJgEH6p9tcPQkBAUoXqEZFwSBtHtNo1etfa1Eityg3fC55qDvQ==
+"@types/react-relay@^16.0.6":
+  version "16.0.6"
+  resolved "https://registry.yarnpkg.com/@types/react-relay/-/react-relay-16.0.6.tgz#afc467fab89dc4c96fb1424f84b869750f5c42f2"
+  integrity sha512-VTntVQJhlwQYNUlbNgGf8RYy7EtQPRZqsD/w2Si0ygZspJXuNlVdRkklWMFN99EMRhHDpqlNHD8i3wIs7QRz9g==
   dependencies:
     "@types/react" "*"
     "@types/relay-runtime" "*"
@@ -9549,16 +9549,16 @@ react-refresh@^0.14.0, react-refresh@^0.14.2:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.14.2.tgz#3833da01ce32da470f1f936b9d477da5c7028bf9"
   integrity sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==
 
-react-relay@^15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-15.0.0.tgz#0014bea71611ae5cdbd3ef445aa13398fe3372d1"
-  integrity sha512-KWdeMMKMJanOL9LsGZYkyAekayYIi+Y4mbDM8VYbHVPgTWJWAQP6yJKS+V4D17qIMo1L84QJQjGaQWEG139p9Q==
+react-relay@^17.0.0:
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/react-relay/-/react-relay-17.0.0.tgz#1f8b6aefaa73b8af8378300d419289a57a6f94c9"
+  integrity sha512-Kn0CMiKZtWc+EisFPmzuZ53RtDeLlJO+EUVJwqxNkOs5g1jDjVi1v+k48kHeTyim2X43Rr0S2aeailllci5SgQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^3.0.2"
     invariant "^2.2.4"
     nullthrows "^1.1.1"
-    relay-runtime "15.0.0"
+    relay-runtime "17.0.0"
 
 react-shallow-renderer@^16.15.0:
   version "16.15.0"
@@ -9695,10 +9695,10 @@ relay-compiler@^15.0.0:
   resolved "https://registry.yarnpkg.com/relay-compiler/-/relay-compiler-15.0.0.tgz#dafe2227ffe0cda642707a113a52f6c310c5f689"
   integrity sha512-19gIIdrVe/lk7Dkz/hqxpBd54bBDWAKG+kR5ael+xznJPdjlr/rlAmh5Tqi6Mgf/wiEQGdtKiZqeNdOW2/wVRw==
 
-relay-runtime@15.0.0:
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-15.0.0.tgz#e83315ea23925fae8f3317f0091f28924441576f"
-  integrity sha512-7AXkXLQo6gpJNBhk4Kii5b+Yat62HSDD1TgJBi021iSjT1muI8iYd4UZG4f/If209LmaVjkZt2HTNAlk6xtslw==
+relay-runtime@17.0.0:
+  version "17.0.0"
+  resolved "https://registry.yarnpkg.com/relay-runtime/-/relay-runtime-17.0.0.tgz#771084ea3b44f2f1eb578da861511a5558c4e07b"
+  integrity sha512-7b2R3G3DP7VHq7/1ltwQfYn3KkTHIB2NNt3KijIZoNQ73avwpOXBEL0MelSXwq8L+K8lcgAW5VAT7o0LUhnJPQ==
   dependencies:
     "@babel/runtime" "^7.0.0"
     fbjs "^3.0.2"


### PR DESCRIPTION
**Summary**

during the development, we sometimes want to use the different app config for the app without creating a new build.

so we stop to use expo-constants directly but use a wrapper with `useAppConfig()` hook.

At the initial boot, we copy necessary app config fields into local settings storage, and after that, we use the values in the local storage.

**Test**

- yarn test

**Issue**

- N/A