### PR TITLE
[expo][feed] implement Share button

### DIFF
--- a/expo/features/feed/internals/FeedItem.tsx
+++ b/expo/features/feed/internals/FeedItem.tsx
@@ -1,5 +1,3 @@
-import Feather from '@expo/vector-icons/Feather';
-import { useThemeColor } from '@hpapp/features/app/theme';
 import { AmebloIcon } from '@hpapp/features/common';
 import { IconSize, Spacing } from '@hpapp/features/common/constants';
 import { useNavigation } from '@hpapp/features/common/stack';
@@ -10,6 +8,7 @@ import FeedItemAmeblo from './FeedItemAmeblo';
 import FeedItemCTA from './FeedItemCTA';
 import { FeedItemCTADownload } from './FeedItemCTADownload';
 import { FeedItemCTALove } from './FeedItemCTALove';
+import { FeedItemCTAShare } from './FeedItemCTAShare';
 import { FeedItemQuery } from './__generated__/FeedItemQuery.graphql';
 
 const FeedItemQueryGraphQL = graphql`
@@ -30,7 +29,6 @@ export type FeedItemProps = {
 };
 
 export default function FeedItem({ feedId }: FeedItemProps) {
-  const [color] = useThemeColor('secondary');
   const data = useLazyLoadQuery<FeedItemQuery>(FeedItemQueryGraphQL, { feedId });
   const navigation = useNavigation();
   navigation.setOptions({
@@ -43,7 +41,7 @@ export default function FeedItem({ feedId }: FeedItemProps) {
       </View>
       <View style={styles.ctaContainer}>
         {data.node!.assetType === 'ameblo' && <FeedItemCTA label="Open" icon={<AmebloIcon size={IconSize.Medium} />} />}
-        <FeedItemCTA label="Share" icon={<Feather name="share" color={color} size={IconSize.Medium} />} />
+        <FeedItemCTAShare url={data.node!.sourceURL!} />
         <FeedItemCTADownload />
         <FeedItemCTALove />
       </View>

--- a/expo/features/feed/internals/FeedItemCTAShare.tsx
+++ b/expo/features/feed/internals/FeedItemCTAShare.tsx
@@ -1,0 +1,25 @@
+import Feather from '@expo/vector-icons/Feather';
+import { useThemeColor } from '@hpapp/features/app/theme';
+import { IconSize } from '@hpapp/features/common/constants';
+import Share from 'react-native-share';
+
+import FeedItemCTA from './FeedItemCTA';
+
+export type FeedItemCTAShareProps = {
+  url: string;
+};
+
+export function FeedItemCTAShare(props: FeedItemCTAShareProps) {
+  const [color] = useThemeColor('secondary');
+  return (
+    <FeedItemCTA
+      label="Share"
+      icon={<Feather name="share" color={color} size={IconSize.Medium} />}
+      onPress={async () => {
+        await Share.open({
+          url: props.url
+        });
+      }}
+    />
+  );
+}

--- a/expo/jest.setup.tsx
+++ b/expo/jest.setup.tsx
@@ -149,6 +149,10 @@ jest.mock('@react-native-firebase/auth', () => {
   return module;
 });
 
+jest.mock('react-native-share', () => ({
+  default: jest.fn()
+}));
+
 jest.mock('@hpapp/system/graphql/relay');
 
 jest.setTimeout(5000);

--- a/expo/package.json
+++ b/expo/package.json
@@ -75,6 +75,7 @@
     "react-native-root-toast": "^3.5.1",
     "react-native-safe-area-context": "4.10.1",
     "react-native-screens": "3.31.1",
+    "react-native-share": "^11.0.4",
     "react-native-svg": "^15.3.0",
     "react-native-tab-view": "^3.5.2",
     "react-native-vector-icons": "^10.1.0",

--- a/expo/yarn.lock
+++ b/expo/yarn.lock
@@ -13881,6 +13881,11 @@ react-native-screens@3.31.1:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"
 
+react-native-share@^11.0.4:
+  version "11.0.4"
+  resolved "https://registry.yarnpkg.com/react-native-share/-/react-native-share-11.0.4.tgz#9d7ed7b15e68aa739fc0cbb67738b650f878ed80"
+  integrity sha512-i91n1Pcdaxxr39uxR5KduXjqi5FSEXuEO6rmeHl8OPs5rqo4No36qJXUU6du4TZUI6tFSENdxnzZMh3OsMF+ug==
+
 react-native-size-matters@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/react-native-size-matters/-/react-native-size-matters-0.4.0.tgz#01bfd0d59454318f4e0b13fe9c1eb0523d70f2e0"


### PR DESCRIPTION
**Summary**

In 2.x, we have a Tweet button in the FeedItem component but we don't have it in 3.x. We use the Share button instead of the Tweet button to have better control of where to share.

This PR is a minimum implementation of the Share button.

**Test**

- expo

**Issue**

- #88