### PR TITLE
[expo] add upfc.jp support

### DIFF
--- a/expo/features/upfc/internals/UPFCApplicationStatusLabel.tsx
+++ b/expo/features/upfc/internals/UPFCApplicationStatusLabel.tsx
@@ -6,6 +6,7 @@ import { ThemeColorScheme } from '@hpapp/system/theme';
 import { View, StyleSheet } from 'react-native';
 
 const StatusColorScheme: Record<string, ThemeColorScheme> = {
+  // 抽選前: 'success',
   申込済: 'success',
   入金待: 'error',
   入金済: 'primary',
@@ -19,7 +20,7 @@ export type UPFCApplicationStatusLabelProps = {
 };
 
 export default function UPFCApplicationStatusLabel({ ticket }: UPFCApplicationStatusLabelProps) {
-  const [color, contrast] = useThemeColor(StatusColorScheme[ticket.status]);
+  const [color, contrast] = useThemeColor(StatusColorScheme[ticket.status] ?? 'warning');
   return (
     <View style={[styles.container, { backgroundColor: color }]}>
       <Text style={[styles.text, { color: contrast }]}>{ticket.status}</Text>

--- a/expo/features/upfc/internals/settings/UPFCSettingsForm.tsx
+++ b/expo/features/upfc/internals/settings/UPFCSettingsForm.tsx
@@ -1,7 +1,12 @@
 import { useAppConfig, useUPFCConfigUpdator, useUPFCConfig } from '@hpapp/features/app/settings';
 import { useThemeColor } from '@hpapp/features/app/theme';
 import { Spacing } from '@hpapp/features/common/constants';
-import { UPFCDemoScraper, UPFCHttpFetcher, UPFCSiteScraper, ErrUPFCAuthentication } from '@hpapp/features/upfc/scraper';
+import {
+  UPFCDemoScraper,
+  ErrUPFCAuthentication,
+  UPFC2SiteScraper,
+  UPFC2HttpFetcher
+} from '@hpapp/features/upfc/scraper';
 import { t } from '@hpapp/system/i18n';
 import { Button } from '@rneui/themed';
 import { useCallback, useState } from 'react';
@@ -50,7 +55,7 @@ export default function UPFCSettingsForm({ onSave }: UPFCSettingsFormProps) {
       try {
         const scraper = appConfig.useUPFCDemoScraper
           ? new UPFCDemoScraper()
-          : new UPFCSiteScraper(new UPFCHttpFetcher());
+          : new UPFC2SiteScraper(new UPFC2HttpFetcher());
         if (hpUsername !== '') {
           const ok = await scraper.authenticate(hpUsername, hpPassword, 'helloproject');
           if (!ok) {

--- a/expo/features/upfc/internals/useUPFCEventApplications.tsx
+++ b/expo/features/upfc/internals/useUPFCEventApplications.tsx
@@ -3,11 +3,14 @@ import { useReloadableAsync, ReloadableAysncResult } from '@hpapp/features/commo
 import {
   ErrUPFCAuthentication,
   ErrUPFCNoCredential,
+  UPFC2HttpFetcher,
+  UPFC2SiteScraper,
   UPFCDemoScraper,
   UPFCEventApplicationTickets,
   UPFCHttpFetcher,
   UPFCSite,
-  UPFCSiteScraper
+  UPFCSiteScraper,
+  UPFCCombiedSiteScraper
 } from '@hpapp/features/upfc/scraper';
 import { isEmpty } from '@hpapp/foundation/string';
 import { useMemo } from 'react';
@@ -64,6 +67,8 @@ export default function useUPFCEventApplications(): ReloadableAysncResult<
 
 const demoScraper = new UPFCDemoScraper();
 const siteScraper = new UPFCSiteScraper(new UPFCHttpFetcher());
+const siteScraper2 = new UPFC2SiteScraper(new UPFC2HttpFetcher());
+const combinedScraper = new UPFCCombiedSiteScraper([siteScraper2, siteScraper]);
 
 async function fetchApplications({
   helloproject,
@@ -95,7 +100,7 @@ async function fetchApplicationsFromSite(
   error: Error | undefined;
   applications: UPFCEventApplicationTickets[];
 }> {
-  const scraper = useDemo ? demoScraper : siteScraper;
+  const scraper = useDemo ? demoScraper : combinedScraper;
   if (isEmpty(username)) {
     return {
       error: new ErrUPFCNoCredential(),

--- a/expo/features/upfc/scraper/index.ts
+++ b/expo/features/upfc/scraper/index.ts
@@ -1,3 +1,6 @@
+import UPFC2HttpFetcher from './internals/UPFC2HttpFetcher';
+import UPFC2SiteScraper from './internals/UPFC2SiteScraper';
+import UPFCCombiedSiteScraper from './internals/UPFCCombinedSiteScraper';
 import UPFCDemoScraper from './internals/UPFCDemoScraper';
 import UPFCHttpFetcher from './internals/UPFCHttpFetcher';
 import UPFCSiteScraper from './internals/UPFCSiteScraper';
@@ -5,4 +8,11 @@ import UPFCSiteScraper from './internals/UPFCSiteScraper';
 export * from './internals/types';
 export * from './internals/errors';
 
-export { UPFCDemoScraper, UPFCSiteScraper, UPFCHttpFetcher };
+export {
+  UPFCDemoScraper,
+  UPFCCombiedSiteScraper,
+  UPFCSiteScraper,
+  UPFCHttpFetcher,
+  UPFC2SiteScraper,
+  UPFC2HttpFetcher
+};

--- a/expo/features/upfc/scraper/internals/UPFC2SiteScraper.test.ts
+++ b/expo/features/upfc/scraper/internals/UPFC2SiteScraper.test.ts
@@ -1,0 +1,39 @@
+import { UPFC2SiteScraper, UPFCEventApplicationTickets } from '@hpapp/features/upfc/scraper';
+import { readFileAsJSON } from '@hpapp/foundation/test_helper';
+import * as path from 'path';
+
+import UPFCFileFetcher from './UPFCFileFetcher';
+
+describe('UPFCSiteScraper', () => {
+  describe('helloproject', () => {
+    describe('getEventApplications', () => {
+      it('should return all Applications listed in applications and mypage', async () => {
+        const fetcher = new UPFCFileFetcher('mizuki', 'fukumura', {
+          redirectPageHtmlPath: path.join(__dirname, './testdata/upfc2/valid-redirect.html'),
+          openEventApplicationsHtmlPath: path.join(__dirname, './testdata/upfc2/valid-available-applications.html'),
+          ticketsHtmlPath: path.join(__dirname, './testdata/upfc2/valid-tickets-page.html'),
+          applicationDetailHtmlPath: path.join(__dirname, './testdata/upfc2/valid-available-application-detail.html'),
+          ticketDetailHtmlPath: path.join(__dirname, './testdata/upfc2/valid-ticket-detail.html')
+        });
+        const scraper = new UPFC2SiteScraper(fetcher);
+        const got = await scraper.getEventApplications('helloproject');
+        const expected = await readFileAsJSON<UPFCEventApplicationTickets[]>(
+          path.join(__dirname, './testdata/upfc2/valid.expected.json')
+        );
+        expect(got.length).toBe(expected.length);
+        expected.forEach((e, i) => {
+          const g = got[i];
+          expect(g.name).toBe(e.name);
+          expect(g.site).toBe('helloproject');
+          expect(g.applicationID).toBe(e.applicationID);
+          if (g.applicationStartDate !== undefined) {
+            expect(g.applicationStartDate!.getTime()).toBe(new Date(e.applicationStartDate!).getTime());
+            expect(g.applicationDueDate!.getTime()).toBe(new Date(e.applicationDueDate!).getTime());
+            expect(g.paymentOpenDate!.getTime()).toBe(new Date(e.paymentOpenDate!).getTime());
+            expect(g.paymentDueDate!.getTime()).toBe(new Date(e.paymentDueDate!).getTime());
+          }
+        });
+      });
+    });
+  });
+});

--- a/expo/features/upfc/scraper/internals/UPFC2SiteScraper.ts
+++ b/expo/features/upfc/scraper/internals/UPFC2SiteScraper.ts
@@ -1,0 +1,329 @@
+import { parse } from 'node-html-parser';
+
+import { ErrUPFCAuthentication } from './errors';
+import {
+  UPFCScraper,
+  UPFCEventApplication,
+  UPFCEventApplicationTickets,
+  UPFCFetcher,
+  UPFCTicketApplicationStatus,
+  UPFCSite,
+  UPFCEventTicket
+} from './types';
+
+/**
+ * UPFC2SiteScraper implements UPFCScraper that scrapes html returned by upfc.jp
+ */
+export default class UPFC2SiteScraper implements UPFCScraper {
+  private readonly fetcher: UPFCFetcher;
+
+  constructor(fetcher: UPFCFetcher) {
+    this.fetcher = fetcher;
+  }
+
+  /**
+   * authenticate with upfc.jp
+   * @param username fan club number
+   * @param password password
+   * @returns
+   */
+  async authenticate(username: string, password: string, site: UPFCSite): Promise<boolean> {
+    const html = await this.fetcher.postCredential(username, password, site);
+    if (!this.parseRedirectPageHTML(html)) {
+      throw new ErrUPFCAuthentication();
+    }
+    return true;
+  }
+
+  /**
+   * @returns a list of event applications
+   */
+  async getEventApplications(site: UPFCSite): Promise<UPFCEventApplicationTickets[]> {
+    const events = this.fetcher.fetchEventApplicationsHtml(site);
+    const tickets = this.fetcher.fetchTicketsHtml(site);
+    const [eventsHtml, ticketsHtml] = await Promise.all([events, tickets]);
+    return await this.parseEventApplications(site, eventsHtml, ticketsHtml);
+  }
+
+  parseRedirectPageHTML(text: string) {
+    const doc = parse(text);
+    const meta = doc.getElementsByTagName('title');
+    // confirm login page is not displayed.
+    if (meta.length === 1 && meta[0].innerHTML !== 'ログイン') {
+      return true;
+    }
+    return false;
+  }
+
+  async parseEventApplications(
+    site: UPFCSite,
+    eventsHtml: string,
+    ticketsHtml: string
+  ): Promise<UPFCEventApplicationTickets[]> {
+    // events avaialble on upfc.jp
+    const events = await this.parseEventApplicationsHtml(site, eventsHtml);
+    // tickets available on upfc.jp including past events
+    const ticketApplications = await this.parseTicketsHtml(site, ticketsHtml);
+    const result: UPFCEventApplicationTickets[] = [];
+    const eventMap: Map<string, UPFCEventApplicationTickets> = new Map();
+
+    // 1) convert all available events to a map and record to the result as UPFCEventApplicationTickets
+    events.forEach((e) => {
+      if (!eventMap.has(e.applicationID!)) {
+        const eat = {
+          ...e,
+          tickets: []
+        };
+        eventMap.set(e.applicationID!, eat);
+        result.push(eat);
+      }
+    });
+
+    // 2) then fill the ticket innformation from ticketApplications
+    //    if an event is not available in the eventMap, it means the event is no longer visible on upfc.jp
+    //    but we can just push the ticketApplications to the result as a past event
+    ticketApplications.forEach((a) => {
+      if (eventMap.has(a.applicationID!)) {
+        const existing = eventMap.get(a.applicationID!)!;
+        existing.tickets = a.tickets;
+      } else {
+        result.push(a);
+      }
+    });
+    return result;
+  }
+
+  async parseEventApplicationsHtml(site: UPFCSite, text: string): Promise<UPFCEventApplication[]> {
+    const doc = parse(text);
+    const links = doc.querySelectorAll('li.p-list__li a');
+    if (links === null) {
+      return [];
+    }
+    const applications: UPFCEventApplication[] = [];
+    for (let i = 0; i < links.length; i++) {
+      const link = links[i];
+      const href = link.getAttribute('href');
+      const titleH3 = link.querySelector('h3.event_ttl');
+      if (!href || !titleH3) {
+        continue;
+      }
+      const match = href.match(/event_info\.php\?@uid=(.+)/);
+      if (match?.length !== 2) {
+        continue;
+      }
+      applications.push({
+        name: this.normalizeApplicationName(titleH3.textContent.trim()),
+        site,
+        applicationID: match![1]
+      });
+    }
+    return (await Promise.all(
+      applications.map(async (a) => {
+        try {
+          const applicationDetailHtml = await this.fetcher.fetchEventApplicationDetailHtml(site, a.applicationID!);
+          const details = this.parseEventApplicationDetailHtml(site, applicationDetailHtml);
+          return {
+            ...a,
+            ...details
+          };
+        } catch {
+          // ignore error as we need to debug anyway.
+          return a;
+        }
+      })
+    )) as UPFCEventApplicationTickets[];
+  }
+
+  parseEventApplicationDetailHtml(
+    site: UPFCSite,
+    detailHtml: string
+  ): {
+    applicationStartDate?: Date;
+    applicationDueDate?: Date;
+    paymentOpenDate?: Date;
+    paymentDueDate?: Date;
+  } {
+    const obj: {
+      applicationStartDate?: Date;
+      applicationDueDate?: Date;
+      paymentOpenDate?: Date;
+      paymentDueDate?: Date;
+    } = {};
+    const dom = parse(detailHtml);
+    const rows = dom.querySelectorAll('table tbody tr');
+    if (rows === null) {
+      return obj;
+    }
+    for (let i = 0; i < rows.length; i++) {
+      const tr = rows[i];
+      const th = tr.querySelector('th')?.textContent.trim();
+      const text = tr.querySelector('td')?.textContent.trim();
+      if (th === undefined || text === undefined) {
+        continue;
+      }
+      const dates = this.parseApplicationDates(text);
+      switch (th) {
+        case '申込期間':
+          if (dates !== null) {
+            obj.applicationStartDate = dates[0];
+            obj.applicationDueDate = dates[1];
+          }
+          break;
+        case '当選・落選確認期間':
+          if (dates !== null) {
+            obj.paymentOpenDate = dates[0];
+            obj.paymentDueDate = dates[1];
+          }
+          break;
+      }
+    }
+    return obj;
+  }
+
+  async parseTicketsHtml(site: UPFCSite, ticketsHtml: string): Promise<UPFCEventApplicationTickets[]> {
+    const doc = parse(ticketsHtml);
+    const links = doc.querySelectorAll('a');
+    if (links === null) {
+      return [];
+    }
+
+    const applicaions: UPFCEventApplication[] = [];
+    for (let i = 0; i < links.length; i++) {
+      const link = links[i];
+      const href = link.getAttribute('href');
+      const titleH5 = link.querySelector('h5');
+      if (!href || !titleH5) {
+        continue;
+      }
+      const match = href.match(/event_payment\.php\?@uid=(.+)/);
+      if (match?.length !== 2) {
+        continue;
+      }
+      const applicationID = match[1];
+      const applicationName = this.normalizeApplicationName(titleH5.textContent.trim());
+      applicaions.push({
+        name: applicationName,
+        site,
+        applicationID
+      });
+    }
+
+    return (
+      await Promise.all(
+        applicaions.map(async (a) => {
+          try {
+            const ticketDetailHtml = await this.fetcher.fetchTicketDetailHtml(site, a.applicationID!);
+            const tickets = await this.parseTicketDetailHtml(site, ticketDetailHtml);
+            return {
+              ...a,
+              tickets
+            };
+          } catch {
+            // ignore error as we need to debug anyway.
+            return null;
+          }
+        })
+      )
+    ).filter((a) => a !== null) as UPFCEventApplicationTickets[];
+  }
+
+  private parseApplicationDates(text: string): [Date, Date] | null {
+    const m = text.match(
+      /(?<start_y>\d{4})年(?<start_m>\d{1,2})月(?<start_d>\d{1,2})日（.+）(?<start_h>\d{1,2})時～(?<end_m>\d{1,2})月(?<end_d>\d{1,2})日（.+）(?<end_h>\d{1,2})時/
+    );
+    const groups = m?.groups;
+    if (groups === undefined) {
+      return null;
+    }
+    // NOTE: does upfc cover applications that run into the next year? probably no?
+    return [
+      new Date(
+        `${groups.start_y}-${this.formatN(groups.start_m)}-${this.formatN(groups.start_d)}T${this.formatN(groups.start_m)}:00:00+09:00`
+      ),
+      new Date(
+        `${groups.start_y}-${this.formatN(groups.end_m)}-${this.formatN(groups.end_d)}T${this.formatN(groups.end_m)}:00:00+09:00`
+      )
+    ];
+  }
+
+  private async parseTicketDetailHtml(site: UPFCSite, detailHtml: string): Promise<UPFCEventTicket[]> {
+    const tickets = [] as UPFCEventTicket[];
+    const dom = parse(detailHtml);
+    const rows = dom.querySelectorAll('table tbody tr');
+    if (rows === null) {
+      return [];
+    }
+    for (let i = 0; i < rows.length; i++) {
+      const tr = rows[i];
+      const status = this.parseTicketStatus(tr.querySelector('td.bingo ul li')!.textContent.trim());
+      const show = this.parseTicketShow(tr.querySelector('td.show')!.textContent.trim());
+      const num = this.parseNumTickets(tr.querySelector('td.ticket')!.textContent.trim());
+      if (show === null) {
+        continue;
+      }
+      tickets.push({
+        status,
+        num,
+        ...show
+      });
+    }
+    return tickets;
+  }
+
+  private normalizeApplicationName(valueStr: string) {
+    // upfc sometimes use different characters for the same character
+    // モーニング娘。'24 (correct) vs モーニング娘。’24 (incorrect)
+    return valueStr.replace('■', '').replace('\u2019', "'").trim();
+  }
+
+  private parseTicketStatus(valueStr: string): UPFCTicketApplicationStatus {
+    if (valueStr.indexOf('抽選前') >= 0) {
+      return '抽選前';
+    }
+    if (valueStr.indexOf('落選') >= 0) {
+      return '落選';
+    }
+    if (valueStr.indexOf('当選') >= 0) {
+      if (valueStr.indexOf('入金済') >= 0) {
+        return '入金済';
+      }
+      return '入金待';
+    }
+    return '不明';
+  }
+
+  private parseNumTickets(valueStr: string): number {
+    const m = valueStr.match(/(\d+)\s*枚/);
+    if (m !== null) {
+      return parseInt(m[1], 10);
+    }
+    return 0;
+  }
+
+  private parseTicketShow(valueStr: string): { venue: string; startAt: Date; openAt: Date } | null {
+    const m1 = valueStr.match(
+      /(?<date_y>\d{4})\.(?<date_m>\d{1,2})\.(?<date_d>\d{1,2})（(.+)）\s+(?<location>[^:]+):(?<venue>[^\s]+)/
+    );
+    const m2 = valueStr.match(/開場(?<open_time>\d{2}:\d{2})\s+開演(?<start_time>\d{2}:\d{2})/);
+    const g1 = m1?.groups;
+    const g2 = m2?.groups;
+    if (g1 === undefined || g2 === undefined) {
+      return null;
+    }
+    return {
+      // we keep "location venue" format, which was used in up-fc.jp.
+      venue: `${g1.location} ${g1.venue}`,
+      startAt: new Date(`${g1.date_y}-${this.formatN(g1.date_m)}-${this.formatN(g1.date_d)}T${g2.start_time}:00+09:00`),
+      openAt: new Date(`${g1.date_y}-${this.formatN(g1.date_m)}-${this.formatN(g1.date_d)}T${g2.open_time}:00+09:00`)
+    };
+  }
+
+  private formatN(n: string): string {
+    if (n.length === 1) {
+      return `0${n}`;
+    }
+    return n;
+  }
+}
+
+export { UPFCScraper };

--- a/expo/features/upfc/scraper/internals/UPFCCombinedSiteScraper.tsx
+++ b/expo/features/upfc/scraper/internals/UPFCCombinedSiteScraper.tsx
@@ -1,0 +1,23 @@
+import { UPFCEventApplicationTickets, UPFCScraper, UPFCSite } from './types';
+
+/**
+ * UPFCCombiedSiteScraper implements UPFCScraper with multiple scraper instances.
+ */
+export default class UPFCCombiedSiteScraper implements UPFCScraper {
+  scrapers: UPFCScraper[];
+
+  constructor(scrapers: UPFCScraper[]) {
+    this.scrapers = scrapers;
+  }
+
+  public async authenticate(username: string, password: string, site: UPFCSite): Promise<boolean> {
+    const results = await Promise.all(this.scrapers.map((s) => s.authenticate(username, password, site)));
+    // some scraper may fail but ignore if at least one succeeded
+    return results.some((r) => r === true);
+  }
+
+  public async getEventApplications(site: UPFCSite): Promise<UPFCEventApplicationTickets[]> {
+    const results = await Promise.all(this.scrapers.map((s) => s.getEventApplications(site)));
+    return results.flat();
+  }
+}

--- a/expo/features/upfc/scraper/internals/UPFCFileFetcher.ts
+++ b/expo/features/upfc/scraper/internals/UPFCFileFetcher.ts
@@ -1,3 +1,4 @@
+import { isEmpty } from '@hpapp/foundation/string';
 import { readFile } from '@hpapp/foundation/test_helper';
 
 /**
@@ -9,8 +10,10 @@ export default class UPFCFileFetcher {
   private paths: {
     redirectPageHtmlPath: string;
     openEventApplicationsHtmlPath: string;
-    openExecEventApplicationsHtmlPath: string;
+    openExecEventApplicationsHtmlPath?: string;
+    applicationDetailHtmlPath?: string;
     ticketsHtmlPath: string;
+    ticketDetailHtmlPath?: string;
   };
 
   constructor(
@@ -19,8 +22,10 @@ export default class UPFCFileFetcher {
     paths: {
       redirectPageHtmlPath: string;
       openEventApplicationsHtmlPath: string;
-      openExecEventApplicationsHtmlPath: string;
+      openExecEventApplicationsHtmlPath?: string;
+      applicationDetailHtmlPath?: string;
       ticketsHtmlPath: string;
+      ticketDetailHtmlPath?: string;
     }
   ) {
     this.username = username;
@@ -40,11 +45,28 @@ export default class UPFCFileFetcher {
   }
 
   async fetchExecEventApplicationsHtml(): Promise<string> {
-    return await this.readFile(this.paths.openExecEventApplicationsHtmlPath);
+    if (isEmpty(this.paths.openExecEventApplicationsHtmlPath)) {
+      return '';
+    }
+    return await this.readFile(this.paths.openExecEventApplicationsHtmlPath!);
   }
 
   async fetchTicketsHtml(): Promise<string> {
     return await this.readFile(this.paths.ticketsHtmlPath);
+  }
+
+  async fetchEventApplicationDetailHtml(): Promise<string> {
+    if (isEmpty(this.paths.applicationDetailHtmlPath)) {
+      return '';
+    }
+    return await this.readFile(this.paths.applicationDetailHtmlPath!);
+  }
+
+  async fetchTicketDetailHtml(): Promise<string> {
+    if (isEmpty(this.paths.ticketDetailHtmlPath)) {
+      return '';
+    }
+    return await this.readFile(this.paths.ticketDetailHtmlPath!);
   }
 
   async readFile(path: string): Promise<string> {

--- a/expo/features/upfc/scraper/internals/UPFCSiteScraper.ts
+++ b/expo/features/upfc/scraper/internals/UPFCSiteScraper.ts
@@ -56,7 +56,7 @@ export default class UPFCSiteScraper implements UPFCScraper {
       if (equiv && equiv.toLowerCase() === 'refresh') {
         const content = meta[i].getAttribute('content') as string | null;
         // eslint-disable-next-line quotes
-        if (content && content.toLowerCase().indexOf('index.php') >= 0) {
+        if (content && content.toLowerCase().indexOf('mypage01.php') >= 0) {
           return true;
         }
       }

--- a/expo/features/upfc/scraper/internals/testdata/upfc2/valid-available-application-detail.html
+++ b/expo/features/upfc/scraper/internals/testdata/upfc2/valid-available-application-detail.html
@@ -1,0 +1,445 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta charset="UTF-8" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+
+    <link rel="stylesheet" type="text/css" href="/helloproject/css/import.css" media="all" />
+    <link rel="stylesheet" type="text/css" href="/helloproject/css/app.css" media="all" />
+
+    <link rel="icon" href="./favicon.png" type="image/vnd.microsoft.icon" />
+    <link rel="apple-touch-icon" sizes="152x152" href="./img/cmn/apple-touch-icon.png" />
+
+    <script src="/helloproject/js/jquery-3.5.1.min.js"></script>
+
+    <!-- font-awsome -->
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+
+    <!-- google font-->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@600&family=Josefin+Sans:wght@700&family=Noto+Sans+JP:wght@400;500;700&family=EB+Garamond&display=swap" rel="stylesheet"> -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Anta&family=Barlow:wght@600&family=Josefin+Sans:wght@700&family=M+PLUS+Rounded+1c:wght@700&family=Noto+Sans+JP:wght@500;600;900&display=swap"
+      rel="stylesheet"
+    />
+
+    <title>イベント詳細</title>
+    <meta name="keyword" content="" />
+    <meta name="description" content="" />
+
+    <meta property="og:url" content="https://upfc.jp/helloproject/event/event_info.php?@uid=wSjsyWxBARuW4eqn" />
+    <meta property="og:title" content="イベント詳細" />
+    <meta property="og:description" content="" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="/helloproject/images/site_image.png" />
+    <meta name="twitter:card" content="summary" />
+
+    <script>
+      var _sort_tbl_ = '';
+    </script>
+    <style type="text/css"></style>
+    <script type="text/javascript">
+      $(function () {});
+    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6N6N1FYXBX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'G-6N6N1FYXBX');
+    </script>
+  </head>
+
+  <body class="app__page">
+    <header id="top" class="">
+      <div class="hd__inner">
+        <div class="hd__flex flex jc-between align-items">
+          <div class="hd__left">
+            <h1 class="hd__logo">
+              <a href="/helloproject/"
+                ><img
+                  src="/helloproject/images/cmn/hd_logo.svg"
+                  alt="Hello! Projectオフィシャルファンクラブ"
+                  loading="lazy"
+              /></a>
+            </h1>
+          </div>
+
+          <nav class="g-nav__pc pc color-ma">
+            <ul class="g-nav__pc--ul flex jc-center">
+              <li class="g-nav__li news"><a href="/helloproject/news_list.php?@rst=all">ファンクラブニュース</a></li>
+
+              <li class="g-nav__li mypage"><a href="/helloproject/mypage/">マイページ</a></li>
+              <li class="g-nav__li membercard"><a href="/helloproject/mypage/member_card.php">会員証</a></li>
+
+              <!-- <li class="g-nav__li service"><a href="/helloproject/service.php">サービス一覧</a></li> -->
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <div class="g-nav__bg">
+      <div class="g-nav__bg--inner">
+        <nav class="g-nav__sp">
+          <h3 class="menu_ttl">MEMBER'S MENU</h3>
+
+          <div class="menu_logout"><a href="/helloproject/logout.php">LOGOUT</a></div>
+
+          <ul class="g-nav__sp-ul">
+            <li class="g-nav__li mypage"><a href="/helloproject/mypage/">マイページ</a></li>
+            <li class="g-nav__li news"><a href="/helloproject/news_list.php?@rst=all">ファンクラブニュース</a></li>
+            <li class="g-nav__li event"><a href="/helloproject/event/event_list.php?@rst=all">チケット受付</a></li>
+            <li class="g-nav__li shop"><a href="/helloproject/shop/?@rst=all">ファンクラブショップ</a></li>
+            <li class="g-nav__li blog">
+              <a href="/helloproject/staff_report.php?CategoryClear=on&@rst=all">スタッフレポート</a>
+            </li>
+
+            <li class="g-nav__li special"><a href="/helloproject/fan/sp_item_list.php">SP限定ポイントプレゼント</a></li>
+
+            <li class="g-nav__li gold">
+              <a href="/helloproject/fan/spgold_item_list.php">SP(ゴールド)限定ポイントプレゼント</a>
+            </li>
+            <li class="g-nav__li gold">
+              <a href="/helloproject/fan/spgold_wallpaper.php">SP(ゴールド)限定・オリジナル壁紙</a>
+            </li>
+          </ul>
+
+          <h3 class="menu_ttl">ARTIST</h3>
+
+          <ul class="g-nav__sp-ul column2">
+            <li class="g-nav__li artist MORNING">
+              <a href="/helloproject/artist/?@uid=MORNING&@rst=all">モーニング娘。’24</a>
+            </li>
+            <li class="g-nav__li artist ANGERME">
+              <a href="/helloproject/artist/?@uid=ANGERME&@rst=all">アンジュルム</a>
+            </li>
+            <li class="g-nav__li artist JUICEJUICE">
+              <a href="/helloproject/artist/?@uid=JUICEJUICE&@rst=all">Juice=Juice</a>
+            </li>
+            <li class="g-nav__li artist TSUBAKIFACTORY">
+              <a href="/helloproject/artist/?@uid=TSUBAKIFACTORY&@rst=all">つばきファクトリー</a>
+            </li>
+            <li class="g-nav__li artist BEYOOOOONDS">
+              <a href="/helloproject/artist/?@uid=BEYOOOOONDS&@rst=all">BEYOOOOONDS</a>
+            </li>
+            <li class="g-nav__li artist OCHANORMA">
+              <a href="/helloproject/artist/?@uid=OCHANORMA&@rst=all">OCHA NORMA</a>
+            </li>
+            <li class="g-nav__li artist KENSYUSEI">
+              <a href="/helloproject/artist/?@uid=KENSYUSEI&@rst=all">ハロプロ研修生</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+
+    <div class="hd__gnav--sp hd__menu p-hd__menu">
+      <div class="hd__hamburger ps-r">
+        <span class="hd__hamburger--top ps-a"></span>
+        <span class="hd__hamburger--middle ps-a"></span>
+        <span class="hd__hamburger--bottom ps-a"></span>
+      </div>
+    </div>
+
+    <main class="ps-r">
+      <section class="p-ttl__area mv__area ps-r">
+        <div class="inner">
+          <h2 class="p-ttl"><span class="font-en">CONCERT & EVENTS</span>イベント申し込み</h2>
+        </div>
+      </section>
+
+      <div class="bc__area">
+        <div class="inner">
+          <p class="breadcrumb">
+            <a href="/helloproject/">HOME</a>
+            <span class="arw">&gt;</span>
+            <a href="/helloproject/event/event_list.php">コンサート・イベント一覧</a>
+            <span class="arw">&gt;</span>
+            <span class="current">コンサート・イベント詳細</span>
+          </p>
+        </div>
+      </div>
+
+      <section class="p-section ps-r">
+        <!-- オブジェクト -->
+        <p class="imoprtant__obj--left ps-a"><img src="/helloproject/images/top/imp_left.png" alt="object" /></p>
+        <p class="imoprtant__obj--right ps-a"><img src="/helloproject/images/top/imp_right.png" alt="object" /></p>
+        <!-- /オブジェクト -->
+
+        <div class="inner">
+          <h3 class="fs-30 color-bl bold mb-30">
+            【先々行受付】Hello! Project 2025 Winter Fes. 「各」／「合」
+            <div class="event_ttl_tag">
+              <span class="tag_ahead">先々行受付</span><span class="tag_event_now">受付中</span>
+            </div>
+          </h3>
+
+          <div class="preface">
+            <p>以下の注意事項を必ずご確認のうえお申し込みください。</p>
+          </div>
+
+          <div id="post_detail" class="event_info mb-60">
+            <div class="mb-30">
+              <table border="1" cellpadding="1" cellspacing="1" style="width: 100%">
+                <tbody>
+                  <tr>
+                    <th scope="row">申込期間</th>
+                    <td>
+                      <span style="color: #3498db">2024年11月8日（金）17時～11月12日（火）17時まで</span><br />
+                      申込後、受付確認メールが届きます。（マイページ内「申込状況＆利用履歴（チケット申込状況）」でもお申込内容の確認が出来ます。）<br />
+                      <span style="color: #e74c3c"
+                        ><span style="font-size: 10.5pt"
+                          ><span style="font-family: Century, serif"
+                            ><span style="font-family: 'ＭＳ Ｐゴシック'"
+                              >※アドレスに変更がある場合は、申込前にマイページの「メールアドレス変更」よりお手続きください。</span
+                            ></span
+                          ></span
+                        ></span
+                      ><br />
+                      ※申込期間内であれば申込内容の変更・キャンセルが可能です。キャンセル後、マイページ内「申込状況＆利用履歴（チケット申込状況）」でご確認ください。（キャンセルの確認メールは送信されません。）<br />
+                      <span style="color: #e74c3c">※「upfc.jp」のメールが受信できるように設定を行ってください。</span>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">当選・落選確認期間</th>
+                    <td>
+                      <span style="color: #3498db">2024年11月13日（水）16時～11月25日（月）23時まで</span><br />
+                      抽選結果は、マイページ内「申込状況＆利用履歴（チケット申込状況）」でのみご案内いたします。当落発表が始まると、お申込みいただいた方全員に「チケット先々行受付抽選結果発表のご案内」をお送りいたします。（当選メールではありません。）必ずご自身で抽選結果をご確認ください。<br />
+                      ※当選された方はマイページ内「申込状況＆利用履歴（チケット申込状況）」よりお支払い方法を選択のうえ、入金締切日までにお支払いをお願いいたします。<br />
+                      <span style="color: #e74c3c"
+                        >（抽選結果確認期間を過ぎるとお手続きができなくなります。ご注意ください。）</span
+                      >
+                    </td>
+                  </tr>
+                  <tr>
+                    <th scope="row">入金締切日</th>
+                    <td><span style="color: #3498db">2024年11月25日（月）</span></td>
+                  </tr>
+                  <tr>
+                    <th scope="row">チケット発送</th>
+                    <td>
+                      <span style="color: #3498db"
+                        >1月2日（木）～1月5日（日）の公演：2024年12月19日（木）に発送予定</span
+                      ><br />
+                      <span style="color: #e74c3c"
+                        >（チケットが届かない場合、12月26日（木）18時までにお問い合わせください。）</span
+                      ><br />
+                      <span style="color: #3498db">1月18日（土）以降の公演：公演9日前に発送予定</span><br />
+                      <br />
+                      簡易書留にて上記日程に発送予定です。<br />
+                      発送が完了しましたら、メールにてお知らせいたします。<br />
+                      ご不在で受け取れなかった場合は、ご不在連絡票がポストに届きますので、ご確認のうえ公演までに必ずお受け取りをお願いいたします。<br />
+                      <span style="color: #e74c3c"
+                        >（会場対応はしておりませんので、必ずご自宅にてチケットをお受取りください。）</span
+                      ><br />
+                      チケットが届かない場合は、公演3日前までに必ずファンクラブにお問い合わせください。<br />
+                      <span style="color: #e74c3c"
+                        >事前に連絡もなくチケットを持たずにお越しいただいた場合、会場での対応はできませんので、くれぐれもご注意ください。</span
+                      >
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+
+            <div class="post_detail">
+              <h4>【お申込みに関してのご注意】</h4>
+
+              <ul class="kome">
+                <li>
+                  <span style="color: #e74c3c"
+                    >品川公演の1F全自由(整理番号付き)は、整理番号順の入場、スタンディングでの鑑賞となります。女性専用エリアを設けます。</span
+                  >
+                </li>
+                <li>
+                  <span style="color: #e74c3c"
+                    >先々行受付では、ファミリー席/2Fファミリー席のお取り扱いはございません。</span
+                  >
+                </li>
+                <li>チケットのお受け取りが可能なお客様のみお申込みをお願いいたします。</li>
+                <li>
+                  チケット料金はファンクラブ特別価格です。一般発売での価格は【品川公演の全自由：￥8,100／それ以外：￥8,600（税込）】になります。
+                </li>
+                <li>車椅子スペースは、状況によってステージが見にくい場合がございます。予めご了承ください。</li>
+                <li>車椅子でお越しの方はチケットが届き次第、各問い合わせ先にご連絡ください。</li>
+                <li>申込期間内であれば申込内容の変更・キャンセルが可能です。</li>
+                <li>
+                  規定枚数に達した場合は厳正なる抽選をさせていただき、落選となる場合がございますので予めご了承ください。
+                </li>
+                <li>
+                  チケット料金の他に1公演ごとに事務手数料（￥830）、コンビニ支払いの場合は支払手数料（￥300）が別途必要です。
+                </li>
+                <li>
+                  ご当選された場合は必ずチケット料金をご入金してください。ご入金がなかった場合は、次回からのチケット受付がご利用できなくなる事もございます。
+                </li>
+                <li>振込受領証は公演終了まで大切に保管してください。</li>
+                <li>チケットの送り先は、ファンクラブに登録されている住所になります。</li>
+                <li>
+                  チケットはいかなる事情（紛失、消失、破損、盗難など）があっても、再発行はいたしません。チケットがない場合、入場ができませんので大切に保管してください。
+                </li>
+              </ul>
+              &nbsp;
+
+              <h4>【公演に関してのご注意】</h4>
+
+              <ul class="kome">
+                <li>開場・開演時間などは変更になる場合もございます。予めご了承ください。</li>
+                <li>
+                  声出しは可能ですが、周囲のお客様のご迷惑となるような声量での継続的な歌唱や声援は、ご遠慮いただきますようお願いいたします。
+                </li>
+                <li>ジャンプ行為は禁止となります。</li>
+                <li>
+                  転売チケット等、不正に購入したチケットで入場を発見した場合は、いかなる理由があっても、その場で退場していただきます。その場合、チケット代の返金はいたしません。（入場口や場内にて、必要に応じて、チケットチェックを実施いたします。ご協力の程お願いいたします。）
+                </li>
+                <li>録音・録画・写真撮影は禁止となります。</li>
+                <li>アルコール類の持ち込み、及び飲酒しての入場は固くお断りいたします。</li>
+                <li>高輝度/扇形/円形/極端に長いサイリウム、誘導灯のご使用は固くお断りいたします。</li>
+                <li>
+                  今後の感染状況により、政府・各自治体の指針・ガイドラインの変更があった場合は、それに基づいた対応をさせていただきます。
+                </li>
+                <li>
+                  出演者は一部変更となる場合がございます。出演者変更によるチケット代金の払い戻しはできませんので、予めご了承ください。
+                </li>
+                <li>
+                  主催者都合による公演中止以外でのチケットの払戻しはできません。<span style="color: #e74c3c"
+                    >公演中止・延期の場合でも事務手数料・コンビニ支払い手数料・交通費・宿泊費・通信費等の補償はできませんので、予めご了承ください。</span
+                  >
+                </li>
+              </ul>
+            </div>
+          </div>
+
+          <div class="ad__btn mb-50">
+            <a class="link__btn03" href="/helloproject/event/event_detail.php">注意事項に同意してお申し込み</a>
+          </div>
+        </div>
+      </section>
+
+      <section class="page-bnrarea ps-r" id="page-bnrarea ">
+        <div class="inner ps-r">
+          <ul class="pick__snswrap flex jc-center align-items wow fadeInUp">
+            <li class="pick__sns">
+              <a href="https://twitter.com/ufi_fc" target="_blank" rel="noopener noreferrer"
+                ><img src="/helloproject/images/cmn/ico_X.png" alt="twitter"
+              /></a>
+            </li>
+            <li class="pick__sns">
+              <a href="https://www.instagram.com/hp_officialfanclub/" target="_blank" rel="noopener noreferrer"
+                ><img src="/helloproject/images/cmn/ico_ig.png" alt="instagram"
+              /></a>
+            </li>
+            <li class="pick__sns">
+              <a href="https://www.youtube.com/@UFfanclub" target="_blank" rel="noopener noreferrer"
+                ><img src="/helloproject/images/cmn/ico_yt.png" alt="youtube"
+              /></a>
+            </li>
+          </ul>
+        </div>
+      </section>
+    </main>
+
+    <footer class="ps-r">
+      <p class="ft__obj01"></p>
+      <p class="ft__obj02"></p>
+      <p class="ft__obj03"></p>
+      <div class="inner ps-r">
+        <h2 class="ft__logo">
+          <a href="index.html"
+            ><img
+              src="/helloproject/images/cmn/hd_logo.svg"
+              alt="オフィシャルファンクラブWEBサイト HELLO! PROJECT SINCE1998"
+              loading="lazy"
+          /></a>
+        </h2>
+
+        <ul class="ft__topnav ft__nav02 flex jc-center">
+          <li class="ft-topnav__li"><a href="/helloproject/mypage/">マイページ</a></li>
+        </ul>
+
+        <div class="ft__flex flex jc-between">
+          <div class="ft__left">
+            <ul class="ft__nav ft__nav03 flex">
+              <li class="ft-nav__li"><a href="/helloproject/news_list.php">ファンクラブニュース</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/service.php">サービス一覧</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/faq.php">よくあるご質問</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/contact.php">お問合せ</a></li>
+              <li class="ft-nav__li sponly"><a href="/helloproject/information.php">サイト案内</a></li>
+              <li class="ft-nav__li sponly"><a href="/helloproject/terms.php">会員規約</a></li>
+              <li class="ft-nav__li sponly"><a href="/helloproject/privacy.php">個人情報保護方針</a></li>
+              <li class="ft-nav__li sponly"><a href="/helloproject/law.php">特定商取引法</a></li>
+            </ul>
+            <ul class="ft__nav ft__nav04 flex spnone">
+              <li class="ft-nav__li"><a href="/helloproject/information.php">サイト案内</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/terms.php">会員規約</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/privacy.php">個人情報保護方針</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/law.php">特定商取引法</a></li>
+            </ul>
+          </div>
+          <div class="ft__right">
+            <div class="ft__infowrap flex jc-end">
+              <div class="ft__info ft__jasrac flex">
+                <p class="ft__info--logo"><img src="/helloproject/images/cmn/jasrac_logo.png" alt="jasrac" /></p>
+                <p class="ft__info--txt">
+                  JASRAC許諾<br />
+                  第6657568030Y31016号<br />
+                  第6657568031Y45037号<br />
+                  第6657568032Y45037号
+                </p>
+              </div>
+              <div class="ft__info ft__jasrac flex">
+                <p class="ft__info--logo"><img src="/helloproject/images/cmn/nextone_logo.png" alt="nexton" /></p>
+                <p class="ft__info--txt">
+                  NexTone許諾<br />
+                  ID000006322<br />
+                  ID000006514
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p class="ft__notice">
+          当サイトに掲載されているすべてのコンテンツ（文章、写真、画像、動画、バナーなど）
+          の著作権はアップフロントインターナショナルに帰属しています。
+        </p>
+        <p class="ft__copyright"><small>© 1998-2024 UP-FRONT INTERNATIONAL Co.,Ltd.</small></p>
+      </div>
+    </footer>
+
+    <p class="js-pagetop" id="page-top">
+      <a href="#top"><img src="/helloproject/images/cmn/pagetop.png" alt="pagetop" /></a>
+    </p>
+
+    <!-- <script src="/helloproject/js/swiper-bundle.min.js"></script> -->
+    <script type="text/javascript" src="/helloproject/js/slick/slick.min.js"></script>
+    <script src="/helloproject/js/wow.min.js"></script>
+    <script>
+      new WOW().init();
+    </script>
+    <script src="/helloproject/js/modaal.min.js"></script>
+    <script>
+      $('.moddal').modaal({
+        overlay_close: true, //モーダル背景クリック時に閉じるか
+        before_open: function () {
+          // モーダルが開く前に行う動作
+          $('html').css('overflow-y', 'hidden'); /*縦スクロールバーを出さない*/
+        },
+        after_close: function () {
+          // モーダルが閉じた後に行う動作
+          $('html').css('overflow-y', 'scroll'); /*縦スクロールバーを出す*/
+        }
+      });
+    </script>
+    <script src="/helloproject/js/script.js"></script>
+  </body>
+</html>

--- a/expo/features/upfc/scraper/internals/testdata/upfc2/valid-available-applications.html
+++ b/expo/features/upfc/scraper/internals/testdata/upfc2/valid-available-applications.html
@@ -1,0 +1,553 @@
+<!DOCTYPE html>
+<html lang="ja">
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta charset="UTF-8" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+
+    <link rel="stylesheet" type="text/css" href="/helloproject/css/import.css" media="all" />
+    <link rel="stylesheet" type="text/css" href="/helloproject/css/app.css" media="all" />
+
+    <link rel="icon" href="./favicon.png" type="image/vnd.microsoft.icon" />
+    <link rel="apple-touch-icon" sizes="152x152" href="./img/cmn/apple-touch-icon.png" />
+
+    <script src="/helloproject/js/jquery-3.5.1.min.js"></script>
+
+    <!-- font-awsome -->
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+
+    <!-- google font-->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@600&family=Josefin+Sans:wght@700&family=Noto+Sans+JP:wght@400;500;700&family=EB+Garamond&display=swap" rel="stylesheet"> -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Anta&family=Barlow:wght@600&family=Josefin+Sans:wght@700&family=M+PLUS+Rounded+1c:wght@700&family=Noto+Sans+JP:wght@500;600;900&display=swap"
+      rel="stylesheet"
+    />
+
+    <title>イベントリスト</title>
+    <meta name="keyword" content="" />
+    <meta name="description" content="" />
+
+    <meta property="og:url" content="https://www.upfc.jp/helloproject/event/event_list.php" />
+    <meta property="og:title" content="イベントリスト" />
+    <meta property="og:description" content="" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="/helloproject/images/site_image.png" />
+    <meta name="twitter:card" content="summary" />
+
+    <script>
+      var _sort_tbl_ = '';
+    </script>
+    <style type="text/css"></style>
+    <script type="text/javascript">
+      $(function () {});
+    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6N6N1FYXBX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'G-6N6N1FYXBX');
+    </script>
+  </head>
+
+  <body class="app__page">
+    <header id="top" class="">
+      <div class="hd__inner">
+        <div class="hd__flex flex jc-between align-items">
+          <div class="hd__left">
+            <h1 class="hd__logo">
+              <a href="/helloproject/"
+                ><img
+                  src="/helloproject/images/cmn/hd_logo.svg"
+                  alt="Hello! Projectオフィシャルファンクラブ"
+                  loading="lazy"
+              /></a>
+            </h1>
+          </div>
+
+          <nav class="g-nav__pc pc color-ma">
+            <ul class="g-nav__pc--ul flex jc-center">
+              <li class="g-nav__li news"><a href="/helloproject/news_list.php?@rst=all">ファンクラブニュース</a></li>
+
+              <li class="g-nav__li mypage"><a href="/helloproject/mypage/">マイページ</a></li>
+              <li class="g-nav__li membercard"><a href="/helloproject/mypage/member_card.php">会員証</a></li>
+
+              <!-- <li class="g-nav__li service"><a href="/helloproject/service.php">サービス一覧</a></li> -->
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <div class="g-nav__bg">
+      <div class="g-nav__bg--inner">
+        <nav class="g-nav__sp">
+          <h3 class="menu_ttl">MEMBER'S MENU</h3>
+
+          <div class="menu_logout"><a href="/helloproject/logout.php">LOGOUT</a></div>
+
+          <ul class="g-nav__sp-ul">
+            <li class="g-nav__li mypage"><a href="/helloproject/mypage/">マイページ</a></li>
+            <li class="g-nav__li news"><a href="/helloproject/news_list.php?@rst=all">ファンクラブニュース</a></li>
+            <li class="g-nav__li event"><a href="/helloproject/event/event_list.php?@rst=all">チケット受付</a></li>
+            <li class="g-nav__li shop"><a href="/helloproject/shop/?@rst=all">ファンクラブショップ</a></li>
+            <li class="g-nav__li blog">
+              <a href="/helloproject/staff_report.php?CategoryClear=on&@rst=all">スタッフレポート</a>
+            </li>
+
+            <li class="g-nav__li special"><a href="/helloproject/fan/sp_item_list.php">SP限定ポイントプレゼント</a></li>
+
+            <li class="g-nav__li gold">
+              <a href="/helloproject/fan/spgold_item_list.php">SP(ゴールド)限定ポイントプレゼント</a>
+            </li>
+            <li class="g-nav__li gold">
+              <a href="/helloproject/fan/spgold_wallpaper.php">SP(ゴールド)限定・オリジナル壁紙</a>
+            </li>
+          </ul>
+
+          <h3 class="menu_ttl">ARTIST</h3>
+
+          <ul class="g-nav__sp-ul column2">
+            <li class="g-nav__li artist MORNING">
+              <a href="/helloproject/artist/?@uid=MORNING&@rst=all">モーニング娘。’24</a>
+            </li>
+            <li class="g-nav__li artist ANGERME">
+              <a href="/helloproject/artist/?@uid=ANGERME&@rst=all">アンジュルム</a>
+            </li>
+            <li class="g-nav__li artist JUICEJUICE">
+              <a href="/helloproject/artist/?@uid=JUICEJUICE&@rst=all">Juice=Juice</a>
+            </li>
+            <li class="g-nav__li artist TSUBAKIFACTORY">
+              <a href="/helloproject/artist/?@uid=TSUBAKIFACTORY&@rst=all">つばきファクトリー</a>
+            </li>
+            <li class="g-nav__li artist BEYOOOOONDS">
+              <a href="/helloproject/artist/?@uid=BEYOOOOONDS&@rst=all">BEYOOOOONDS</a>
+            </li>
+            <li class="g-nav__li artist OCHANORMA">
+              <a href="/helloproject/artist/?@uid=OCHANORMA&@rst=all">OCHA NORMA</a>
+            </li>
+            <li class="g-nav__li artist KENSYUSEI">
+              <a href="/helloproject/artist/?@uid=KENSYUSEI&@rst=all">ハロプロ研修生</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+
+    <div class="hd__gnav--sp hd__menu p-hd__menu">
+      <div class="hd__hamburger ps-r">
+        <span class="hd__hamburger--top ps-a"></span>
+        <span class="hd__hamburger--middle ps-a"></span>
+        <span class="hd__hamburger--bottom ps-a"></span>
+      </div>
+    </div>
+
+    <main class="ps-r">
+      <section class="p-ttl__area mv__area ps-r">
+        <div class="inner">
+          <h2 class="p-ttl"><span class="font-en">CONCERT & EVENTS</span>チケット申し込み</h2>
+        </div>
+      </section>
+
+      <div class="bc__area">
+        <div class="inner">
+          <p class="breadcrumb">
+            <a href="/helloproject/">HOME</a>
+            <span class="arw">&gt;</span>
+            <span class="current">コンサート・イベント一覧</span>
+          </p>
+        </div>
+      </div>
+
+      <section class="p-section ps-r">
+        <div class="inner">
+          <h3 class="p-h3"><span class="mark">■</span>チケット不正転売禁止法施行にあたってのお願い</h3>
+          <p class="lh-2">
+            上記法律の施行により、不正転売の違反者は厳しく処罰される可能性がございます。<br />
+            会員の皆様におかれましては、法令を遵守いただきますようお願いいたします。<br />
+            ※チケットについては主催者の同意なく有償での譲渡を禁止いたします。<br />
+            ※チケットについては申込者の氏名及び連絡先を確認のうえ販売いたします。
+          </p>
+        </div>
+      </section>
+
+      <section class="a-event p-section ps-r" id="a-event">
+        <!-- オブジェクト -->
+        <p class="cal__left ps-a"><img src="/helloproject/images/top/cal_left.png" alt="" /></p>
+        <p class="cal__right ps-a"><img src="/helloproject/images/top/cal_right.png" alt="" /></p>
+        <!-- /オブジェクト -->
+
+        <p class="cal__right--btm ps-a"></p>
+        <div class="inner ps-r">
+          <!-- <h2 class="ae__ttl section__ttl smoothText color-pi mb-60">
+                                        <span class="smoothTextTrigger">
+                                                <strong>CONCERT &amp; EVENTS</strong>
+                                                コンサート・イベント一覧
+                                        </span>
+                                </h2> -->
+
+          <ul class="p-list event_list">
+            <li class="p-list__li">
+              <a href="event_info.php?@uid=7MUPAfEaTTTRLXZ0" class="flex align-items">
+                <div class="p-list__imgwrap">
+                  <figure class="p-list__img">
+                    <img src="/helloproject/images/event/event_7MUPAfEaTTTRLXZ0_1.jpg" alt="" />
+                  </figure>
+                </div>
+                <div class="p-list__ttlwarp">
+                  <div class="event_tag_wrap">
+                    <ul class="event_tag">
+                      <li class="tag_ahead">先々行受付</li>
+                      <li class="tag_event_now">受付中</li>
+                    </ul>
+                  </div>
+                  <h3 class="event_ttl">【先々行受付】モーニング娘。'24 FCイベント ～娘。×FAN×Fun！×クリスマス～</h3>
+                </div>
+              </a>
+            </li>
+            <li class="p-list__li">
+              <a href="event_info.php?@uid=Uy8Dz9edPiWk5F4u" class="flex align-items">
+                <div class="p-list__imgwrap">
+                  <figure class="p-list__img">
+                    <img src="/helloproject/images/event/event_Uy8Dz9edPiWk5F4u_1.jpg" alt="" />
+                  </figure>
+                </div>
+                <div class="p-list__ttlwarp">
+                  <div class="event_tag_wrap">
+                    <ul class="event_tag">
+                      <li class="tag_event_now">受付中</li>
+                    </ul>
+                  </div>
+                  <h3 class="event_ttl">モーニング娘。'24 FCイベント ～娘。×FAN×Fun！×クリスマス～</h3>
+                </div>
+              </a>
+            </li>
+            <li class="p-list__li">
+              <a href="event_info.php?@uid=wSjsyWxBARuW4eqn" class="flex align-items">
+                <div class="p-list__imgwrap">
+                  <figure class="p-list__img">
+                    <img src="/helloproject/images/cmn/event_noimage.png" alt="" />
+                  </figure>
+                </div>
+                <div class="p-list__ttlwarp">
+                  <div class="event_tag_wrap">
+                    <ul class="event_tag">
+                      <li class="tag_ahead">先々行受付</li>
+                      <li class="tag_event_now">受付中</li>
+                    </ul>
+                  </div>
+                  <h3 class="event_ttl">【先々行受付】Hello! Project 2025 Winter Fes. 「各」／「合」</h3>
+                </div>
+              </a>
+            </li>
+            <li class="p-list__li">
+              <a href="event_info.php?@uid=aG1D8uYAQuqRIN7U" class="flex align-items">
+                <div class="p-list__imgwrap">
+                  <figure class="p-list__img">
+                    <img src="/helloproject/images/cmn/event_noimage.png" alt="" />
+                  </figure>
+                </div>
+                <div class="p-list__ttlwarp">
+                  <div class="event_tag_wrap">
+                    <ul class="event_tag">
+                      <li class="tag_event_now">受付中</li>
+                    </ul>
+                  </div>
+                  <h3 class="event_ttl">Hello! Project 2025 Winter Fes. 「各」／「合」</h3>
+                </div>
+              </a>
+            </li>
+            <li class="p-list__li">
+              <a href="event_info.php?@uid=Dppvx3ybTgpPFSFI" class="flex align-items">
+                <div class="p-list__imgwrap">
+                  <figure class="p-list__img">
+                    <img src="/helloproject/images/event/event_Dppvx3ybTgpPFSFI_1.jpg" alt="" />
+                  </figure>
+                </div>
+                <div class="p-list__ttlwarp">
+                  <div class="event_tag_wrap">
+                    <ul class="event_tag">
+                      <li class="tag_event_now">受付中</li>
+                    </ul>
+                  </div>
+                  <h3 class="event_ttl">アンジュルム 川名凜バースデーイベント2024 in 名古屋</h3>
+                </div>
+              </a>
+            </li>
+            <li class="p-list__li">
+              <a href="event_info.php?@uid=ThqFqmVI6ddtIz7m" class="flex align-items">
+                <div class="p-list__imgwrap">
+                  <figure class="p-list__img">
+                    <img src="/helloproject/images/event/event_ThqFqmVI6ddtIz7m_1.jpg" alt="" />
+                  </figure>
+                </div>
+                <div class="p-list__ttlwarp">
+                  <div class="event_tag_wrap">
+                    <ul class="event_tag">
+                      <li class="tag_event_now">受付中</li>
+                    </ul>
+                  </div>
+                  <h3 class="event_ttl">【当日券予約】竹内朱莉バースデーイベント2024～Ⅱ～</h3>
+                </div>
+              </a>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <section class="a-flow p-section ps-r" id="a-flow">
+        <!-- オブジェクト -->
+        <p class="cal__left ps-a"><img src="/helloproject/images/top/cal_left.png" alt="オブジェクト" /></p>
+        <p class="cal__right ps-a"><img src="/helloproject/images/top/cal_right.png" alt="オブジェクト" /></p>
+        <p class="cal__right--btm ps-a"></p>
+        <!-- /オブジェクト -->
+
+        <div class="inner ps-r">
+          <!-- <h2 class="af__ttl section__ttl smoothText color-bl mb-60">
+                                        <span class="smoothTextTrigger">
+                                                <strong>FLOW</strong>
+                                                申し込みの流れ
+                                        </span>
+                                </h2> -->
+
+          <div class="af__ac--btn ac__btn bg-bl ps-r">
+            <h3 class="af__h3 fs-30">チケット受付 申し込みの流れ</h3>
+            <p class="af__notice">チケット受付のお申し込みまでの流れをご説明いたします。</p>
+            <p class="af__arw ps-a"><img src="/helloproject/images/cmn/ac_arw.png" alt="矢印" /></p>
+          </div>
+          <div class="af__ac--area ac__area">
+            <ul class="af__ul">
+              <li>
+                <h4 class="af__h4 fs-18 bold">
+                  <span class="step font-en color-bl fs-30 bold">STEP01</span>公演詳細を確認する
+                </h4>
+                <p class="af__txt">
+                  公演により申込公演制限数・申込枚数制限数などが異なりますので、ご確認のうえお申込みください。
+                </p>
+              </li>
+              <li>
+                <h4 class="af__h4 fs-18 bold"><span class="step font-en color-bl fs-30 bold">STEP02</span>申込み</h4>
+                <p class="af__txt">
+                  公演日・席種等を選択し、お申込をしてください。<br />
+                  <span class="color-red">※座席は全て抽選です。前の席をお取りできるとは限りません。</span>
+                </p>
+              </li>
+              <li>
+                <h4 class="af__h4 fs-18 bold">
+                  <span class="step font-en color-bl fs-30 bold">STEP03</span>申込内容を確認する
+                </h4>
+                <p class="af__txt">
+                  ファンクラブにご登録のアドレスへ「申込確認メール」をお送りいたします。<br />
+                  またマイページの「チケット申込状況」からもお申込内容をご確認いただけます。<br />
+                  ※申込期間内であれば申込内容の変更・キャンセルが可能です。<br />
+                  <span class="color-red"
+                    >※「upfc.jp」のメールが受信できるようにドメイン指定受信等の設定を必ず行ってください。</span
+                  >
+                </p>
+              </li>
+              <li>
+                <h4 class="af__h4 fs-18 bold">
+                  <span class="step font-en color-bl fs-30 bold">STEP04</span>抽選結果を確認する
+                </h4>
+                <p class="af__txt">
+                  お申込みいただいた方全員に「当落確認案内メール」をお送りいたします。（当選メールではありません。）<br />
+                  必ずご自身で抽選結果確認期間中にマイページの「チケット申込状況」にてご確認ください。
+                </p>
+              </li>
+              <li>
+                <h4 class="af__h4 fs-18 bold"><span class="step font-en color-bl fs-30 bold">STEP05</span>お支払い</h4>
+                <p class="af__txt">
+                  <span class="color-red"
+                    >入金がない場合、次回からの受付がご利用できなくなることもございますので、ご注意ください。</span
+                  ><br />
+                  <span class="color-red"
+                    >※ご当選の公演まとめてのお支払いとなります。ご希望の公演のみのお支払いはできません。</span
+                  ><br />
+                  <br />
+
+                  <strong>【コンビニ支払いをご選択の場合】</strong><br />
+                  抽選結果確認期間中にマイページの「チケット申込状況」の「コンビニ支払い」ボタンを押して、コンビニエンスストアを選択してください。<br />
+                  <span class="color-red"
+                    >（抽選結果確認期間を過ぎるとお手続きができなくなります。ご注意ください。）</span
+                  ><br />
+                  コンビニでのお支払いに必要な情報（支払い番号等）が表示されますので、<br />
+                  お支払番号を持参の上、ご指定のコンビニで入金締切日までに現金でお支払いください。<br />
+                  ※お選びいただいたコンビニにより、お支払い方法が異なります。詳しくは<a
+                    class="color-bl"
+                    href="/helloproject/payment_guide.php"
+                    >こちら</a
+                  >でご確認ください。<br />
+                  <span class="color-red"
+                    >手続き完了後、表示されているページは必ずプリントアウト、もしくは保存してください。</span
+                  ><br />
+                  <span class="color-red"
+                    >お支払番号はファンクラブにご登録のメールアドレスにお送りします。また、マイページの「チケット申込状況」でもご確認いただけます。</span
+                  ><br />
+                  ※お支払合計金額は、チケット料金・手数料・コンビニ支払い手数料（￥300）が含まれています。<br />
+                  （ご当選されたすべての公演のチケット料金・手数料の合計となります。）<br />
+                  ※「upfc.jp」のメールが受信できるようにドメイン指定受信等の設定を必ず行ってください。<br />
+                  お支払金額が30万円を超えた場合は、コンビニ決済システムの都合上、コンビニでのお支払いができない為、「郵便局」でのお支払いに限らせていただきます。<br />
+                  コンビニ決済へ進んだ際、エラーメッセージが出ます。その際はファンクラブまでお問い合わせください。<br />
+                  <br />
+
+                  <strong
+                    >【クレジットカード支払いをご選択の場合<span class="color-red">（スペシャル会員のみ）</span
+                    >】</strong
+                  ><br />
+                  ・ご本人様名義のスペシャル会員専用クレジットカード（Hello! Projectカード・Hello!
+                  Projectゴールドカード）のみご利用いただけます。<br />
+                  ・決済は一括払いのみとなります。分割払い・リボ払いは利用できません。<br />
+                  ・決算後の購入の変更・キャンセルはできませんのでご注意ください。<br />
+                  ・決済時に本人認証（3Dセキュア2.0）が必要な場合があります。<br />
+                  3Dセキュア2.0…クレジットカード決済をより安全に行うための本人認証サービスです。カードご利用者様の決済情報等を基にリスクベースの認証を行います。<br />
+                  3Dセキュア2.0での本人認証の場合、取引の大半は追加認証無しに認証が完了いたします。高リスクと判断される取引の場合のみ、ワンタイムパスワード等の追加認証が行われます。<br />
+                  ※お支払合計金額は、チケット料金・手数料が含まれています。
+                </p>
+              </li>
+              <li>
+                <h4 class="af__h4 fs-18 bold">
+                  <span class="step font-en color-bl fs-30 bold">STEP06</span>チケット or 確認メールが届く
+                </h4>
+                <p class="af__txt">
+                  【チケット発送の場合】<br />
+                  チケットは公演ごとに、公演日の約8日前に簡易書留で発送いたします。<br />
+                  紛失・盗難等によるチケットの再発行は一切できませんので、大切に保管してください。その際にはファンクラブでは対応できかねますので、ご了承ください。<br /><br />
+
+                  【確認メール配信の場合】<br />
+                  座席番号またはチケットURLを明記した確認メールをお送りします。（公演日の約7日前頃を予定しております。）<br />
+                  届かない場合は配信日の翌日以降にファンクラブまでご連絡ください。<br />
+                  ※ファンクラブにご登録のメールアドレスへお送りします。アドレスの変更がございましたら事前に登録の変更をお願いいたします。
+                </p>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <section class="page-bnrarea ps-r" id="page-bnrarea ">
+        <div class="inner ps-r">
+          <ul class="pick__snswrap flex jc-center align-items wow fadeInUp">
+            <li class="pick__sns">
+              <a href="https://twitter.com/ufi_fc" target="_blank" rel="noopener noreferrer"
+                ><img src="/helloproject/images/cmn/ico_X.png" alt="twitter"
+              /></a>
+            </li>
+            <li class="pick__sns">
+              <a href="https://www.instagram.com/hp_officialfanclub/" target="_blank" rel="noopener noreferrer"
+                ><img src="/helloproject/images/cmn/ico_ig.png" alt="instagram"
+              /></a>
+            </li>
+            <li class="pick__sns">
+              <a href="https://www.youtube.com/@UFfanclub" target="_blank" rel="noopener noreferrer"
+                ><img src="/helloproject/images/cmn/ico_yt.png" alt="youtube"
+              /></a>
+            </li>
+          </ul>
+        </div>
+      </section>
+    </main>
+
+    <footer class="ps-r">
+      <p class="ft__obj01"></p>
+      <p class="ft__obj02"></p>
+      <p class="ft__obj03"></p>
+      <div class="inner ps-r">
+        <h2 class="ft__logo">
+          <a href="index.html"
+            ><img
+              src="/helloproject/images/cmn/hd_logo.svg"
+              alt="オフィシャルファンクラブWEBサイト HELLO! PROJECT SINCE1998"
+              loading="lazy"
+          /></a>
+        </h2>
+
+        <ul class="ft__topnav ft__nav02 flex jc-center">
+          <li class="ft-topnav__li"><a href="/helloproject/mypage/">マイページ</a></li>
+        </ul>
+
+        <div class="ft__flex flex jc-between">
+          <div class="ft__left">
+            <ul class="ft__nav ft__nav03 flex">
+              <li class="ft-nav__li"><a href="/helloproject/news_list.php">ファンクラブニュース</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/service.php">サービス一覧</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/faq.php">よくあるご質問</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/contact.php">お問合せ</a></li>
+              <li class="ft-nav__li sponly"><a href="/helloproject/information.php">サイト案内</a></li>
+              <li class="ft-nav__li sponly"><a href="/helloproject/terms.php">会員規約</a></li>
+              <li class="ft-nav__li sponly"><a href="/helloproject/privacy.php">個人情報保護方針</a></li>
+              <li class="ft-nav__li sponly"><a href="/helloproject/law.php">特定商取引法</a></li>
+            </ul>
+            <ul class="ft__nav ft__nav04 flex spnone">
+              <li class="ft-nav__li"><a href="/helloproject/information.php">サイト案内</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/terms.php">会員規約</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/privacy.php">個人情報保護方針</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/law.php">特定商取引法</a></li>
+            </ul>
+          </div>
+          <div class="ft__right">
+            <div class="ft__infowrap flex jc-end">
+              <div class="ft__info ft__jasrac flex">
+                <p class="ft__info--logo"><img src="/helloproject/images/cmn/jasrac_logo.png" alt="jasrac" /></p>
+                <p class="ft__info--txt">
+                  JASRAC許諾<br />
+                  第6657568030Y31016号<br />
+                  第6657568031Y45037号<br />
+                  第6657568032Y45037号
+                </p>
+              </div>
+              <div class="ft__info ft__jasrac flex">
+                <p class="ft__info--logo"><img src="/helloproject/images/cmn/nextone_logo.png" alt="nexton" /></p>
+                <p class="ft__info--txt">
+                  NexTone許諾<br />
+                  ID000006322<br />
+                  ID000006514
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p class="ft__notice">
+          当サイトに掲載されているすべてのコンテンツ（文章、写真、画像、動画、バナーなど）
+          の著作権はアップフロントインターナショナルに帰属しています。
+        </p>
+        <p class="ft__copyright"><small>© 1998-2024 UP-FRONT INTERNATIONAL Co.,Ltd.</small></p>
+      </div>
+    </footer>
+
+    <p class="js-pagetop" id="page-top">
+      <a href="#top"><img src="/helloproject/images/cmn/pagetop.png" alt="pagetop" /></a>
+    </p>
+
+    <!-- <script src="/helloproject/js/swiper-bundle.min.js"></script> -->
+    <script type="text/javascript" src="/helloproject/js/slick/slick.min.js"></script>
+    <script src="/helloproject/js/wow.min.js"></script>
+    <script>
+      new WOW().init();
+    </script>
+    <script src="/helloproject/js/modaal.min.js"></script>
+    <script>
+      $('.moddal').modaal({
+        overlay_close: true, //モーダル背景クリック時に閉じるか
+        before_open: function () {
+          // モーダルが開く前に行う動作
+          $('html').css('overflow-y', 'hidden'); /*縦スクロールバーを出さない*/
+        },
+        after_close: function () {
+          // モーダルが閉じた後に行う動作
+          $('html').css('overflow-y', 'scroll'); /*縦スクロールバーを出す*/
+        }
+      });
+    </script>
+    <script src="/helloproject/js/script.js"></script>
+  </body>
+</html>

--- a/expo/features/upfc/scraper/internals/testdata/upfc2/valid-redirect.html
+++ b/expo/features/upfc/scraper/internals/testdata/upfc2/valid-redirect.html
@@ -1,0 +1,16 @@
+<div>
+  <h4>チケット/イベント</h4>
+  <ul class="mypage_entry_box">
+    <li>
+      <a href="/helloproject/mypage/event_payment.php?@uid=7MUPAfEaTTTRLXZ0">
+        <div class="entry_list_top">
+          <ul class="status_label">
+            <li class="lb_gre">抽選前</li>
+          </ul>
+          <h5>【先々行受付】モーニング娘。'24 FCイベント ～娘。×FAN×Fun！×クリスマス～</h5>
+        </div>
+        <div class="entry_list_btm"></div>
+      </a>
+    </li>
+  </ul>
+</div>

--- a/expo/features/upfc/scraper/internals/testdata/upfc2/valid-ticket-detail.html
+++ b/expo/features/upfc/scraper/internals/testdata/upfc2/valid-ticket-detail.html
@@ -1,0 +1,554 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta charset="UTF-8" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+
+    <link rel="stylesheet" type="text/css" href="/helloproject/css/import.css" media="all" />
+    <link rel="stylesheet" type="text/css" href="/helloproject/css/app.css" media="all" />
+
+    <link rel="icon" href="./favicon.png" type="image/vnd.microsoft.icon" />
+    <link rel="apple-touch-icon" sizes="152x152" href="./img/cmn/apple-touch-icon.png" />
+
+    <script src="/helloproject/js/jquery-3.5.1.min.js"></script>
+
+    <!-- font-awsome -->
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+
+    <!-- google font-->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <!-- <link href="https://fonts.googleapis.com/css2?family=Barlow:wght@600&family=Josefin+Sans:wght@700&family=Noto+Sans+JP:wght@400;500;700&family=EB+Garamond&display=swap" rel="stylesheet"> -->
+    <link
+      href="https://fonts.googleapis.com/css2?family=Anta&family=Barlow:wght@600&family=Josefin+Sans:wght@700&family=M+PLUS+Rounded+1c:wght@700&family=Noto+Sans+JP:wght@500;600;900&display=swap"
+      rel="stylesheet"
+    />
+
+    <title>イベント支払</title>
+    <meta name="keyword" content="" />
+    <meta name="description" content="" />
+
+    <meta property="og:url" content="https://www.upfc.jp/helloproject/mypage/event_payment.php?@uid=7MUPAfEaTTTRLXZ0" />
+    <meta property="og:title" content="イベント支払" />
+    <meta property="og:description" content="" />
+    <meta property="og:type" content="website" />
+    <meta property="og:image" content="/helloproject/images/site_image.png" />
+    <meta name="twitter:card" content="summary" />
+
+    <script>
+      var _sort_tbl_ = '';
+    </script>
+    <style type="text/css"></style>
+    <script type="text/javascript">
+      $(function () {});
+    </script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-6N6N1FYXBX"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        dataLayer.push(arguments);
+      }
+      gtag('js', new Date());
+      gtag('config', 'G-6N6N1FYXBX');
+    </script>
+
+    <script type="text/javascript">
+      $(function () {
+        // ページ読み込み完了時
+        $(document).ready(function () {
+          // お支払い方法の選択
+          $('input[name="event_payment"]:radio').on('change', function () {
+            if ($(this).val() == 4) {
+              // 4 クレジットカード
+              $('#payment_card').css('display', 'block');
+              $('#payment_cvs').css('display', 'none');
+              $('#cvs_fee').css('display', 'none');
+            } else {
+              $('#payment_card').css('display', 'none');
+              $('#payment_cvs').css('display', 'block');
+              $('#cvs_fee').css('display', 'flex');
+            }
+          });
+        });
+
+        $('input[name="event_payment"]:radio').trigger('change');
+
+        // 支払いにおける表示の挙動
+        $('input[name="event_payment"]').on('change', function () {
+          let payment = $(this).val();
+          let cvs_fee = Number(
+            $('#cvs_fee')
+              .text()
+              .replace(/(￥|,)/g, '')
+          );
+          let all_sum = Number(
+            $('#all_sum')
+              .text()
+              .replace(/(￥|,)/g, '')
+          );
+          let sum = 0;
+
+          if (payment == 1) {
+            let sum = cvs_fee + all_sum;
+            $('#cvs_fee_block').show();
+            $('#all_sum').text('￥' + sum.toLocaleString());
+          } else {
+            if ($('#cvs_fee_block').is(':visible')) {
+              sum = all_sum - cvs_fee;
+            } else {
+              sum = all_sum;
+            }
+            $('#cvs_fee_block').hide();
+            $('#all_sum').text('￥' + sum.toLocaleString());
+          }
+        });
+      });
+    </script>
+  </head>
+
+  <body class="app__page">
+    <header id="top" class="">
+      <div class="hd__inner">
+        <div class="hd__flex flex jc-between align-items">
+          <div class="hd__left">
+            <h1 class="hd__logo">
+              <a href="/helloproject/"
+                ><img
+                  src="/helloproject/images/cmn/hd_logo.svg"
+                  alt="Hello! Projectオフィシャルファンクラブ"
+                  loading="lazy"
+              /></a>
+            </h1>
+          </div>
+
+          <nav class="g-nav__pc pc color-ma">
+            <ul class="g-nav__pc--ul flex jc-center">
+              <li class="g-nav__li news"><a href="/helloproject/news_list.php?@rst=all">ファンクラブニュース</a></li>
+
+              <li class="g-nav__li mypage"><a href="/helloproject/mypage/">マイページ</a></li>
+              <li class="g-nav__li membercard"><a href="/helloproject/mypage/member_card.php">会員証</a></li>
+
+              <!-- <li class="g-nav__li service"><a href="/helloproject/service.php">サービス一覧</a></li> -->
+            </ul>
+          </nav>
+        </div>
+      </div>
+    </header>
+
+    <div class="g-nav__bg">
+      <div class="g-nav__bg--inner">
+        <nav class="g-nav__sp">
+          <h3 class="menu_ttl">MEMBER'S MENU</h3>
+
+          <div class="menu_logout"><a href="/helloproject/logout.php">LOGOUT</a></div>
+
+          <ul class="g-nav__sp-ul">
+            <li class="g-nav__li mypage"><a href="/helloproject/mypage/">マイページ</a></li>
+            <li class="g-nav__li news"><a href="/helloproject/news_list.php?@rst=all">ファンクラブニュース</a></li>
+            <li class="g-nav__li event"><a href="/helloproject/event/event_list.php?@rst=all">チケット受付</a></li>
+            <li class="g-nav__li shop"><a href="/helloproject/shop/?@rst=all">ファンクラブショップ</a></li>
+            <li class="g-nav__li blog">
+              <a href="/helloproject/staff_report.php?CategoryClear=on&@rst=all">スタッフレポート</a>
+            </li>
+
+            <li class="g-nav__li special"><a href="/helloproject/fan/sp_item_list.php">SP限定ポイントプレゼント</a></li>
+
+            <li class="g-nav__li gold">
+              <a href="/helloproject/fan/spgold_item_list.php">SP(ゴールド)限定ポイントプレゼント</a>
+            </li>
+            <li class="g-nav__li gold">
+              <a href="/helloproject/fan/spgold_wallpaper.php">SP(ゴールド)限定・オリジナル壁紙</a>
+            </li>
+          </ul>
+
+          <h3 class="menu_ttl">ARTIST</h3>
+
+          <ul class="g-nav__sp-ul column2">
+            <li class="g-nav__li artist MORNING">
+              <a href="/helloproject/artist/?@uid=MORNING&@rst=all">モーニング娘。’24</a>
+            </li>
+            <li class="g-nav__li artist ANGERME">
+              <a href="/helloproject/artist/?@uid=ANGERME&@rst=all">アンジュルム</a>
+            </li>
+            <li class="g-nav__li artist JUICEJUICE">
+              <a href="/helloproject/artist/?@uid=JUICEJUICE&@rst=all">Juice=Juice</a>
+            </li>
+            <li class="g-nav__li artist TSUBAKIFACTORY">
+              <a href="/helloproject/artist/?@uid=TSUBAKIFACTORY&@rst=all">つばきファクトリー</a>
+            </li>
+            <li class="g-nav__li artist BEYOOOOONDS">
+              <a href="/helloproject/artist/?@uid=BEYOOOOONDS&@rst=all">BEYOOOOONDS</a>
+            </li>
+            <li class="g-nav__li artist OCHANORMA">
+              <a href="/helloproject/artist/?@uid=OCHANORMA&@rst=all">OCHA NORMA</a>
+            </li>
+            <li class="g-nav__li artist KENSYUSEI">
+              <a href="/helloproject/artist/?@uid=KENSYUSEI&@rst=all">ハロプロ研修生</a>
+            </li>
+          </ul>
+        </nav>
+      </div>
+    </div>
+
+    <div class="hd__gnav--sp hd__menu p-hd__menu">
+      <div class="hd__hamburger ps-r">
+        <span class="hd__hamburger--top ps-a"></span>
+        <span class="hd__hamburger--middle ps-a"></span>
+        <span class="hd__hamburger--bottom ps-a"></span>
+      </div>
+    </div>
+
+    <main class="ps-r">
+      <section class="p-ttl__area mv__area ps-r">
+        <div class="inner">
+          <h2 class="p-ttl"><span class="font-en">MYPAGE</span>イベントお申し込み詳細</h2>
+        </div>
+      </section>
+
+      <div class="bc__area">
+        <div class="inner">
+          <p class="breadcrumb">
+            <a href="/helloproject/">HOME</a>
+            <span class="arw">&gt;</span>
+            <a href="/helloproject/mypage/">マイページ</a>
+            <span class="arw">&gt;</span>
+            <span class="current">イベントお申し込み詳細</span>
+          </p>
+        </div>
+      </div>
+
+      <section class="entry__contents p-section mypage_entry_detail ps-r" id="entry__contents">
+        <!-- オブジェクト -->
+        <p class="cal__left ps-a"><img src="/helloproject/images/top/cal_right.png" alt="" /></p>
+        <!-- /オブジェクト -->
+
+        <div class="inner">
+          <div class="order_number mb-30">
+            <h3 id="event_title" class="ctk__h3 fs-30 bold color-main">
+              【先々行受付】モーニング娘。'24 FCイベント ～娘。×FAN×Fun！×クリスマス～
+            </h3>
+          </div>
+
+          <div>
+            <div id="message" class=""></div>
+          </div>
+
+          <div class="p-box mypage_info_wrap">
+            <div class="cart_fix">
+              <table class="tbl_cart">
+                <thead>
+                  <tr>
+                    <th class="bingo">抽選結果</th>
+                    <th class="show">公演</th>
+                    <th class="seat">席種</th>
+                    <th class="ticket">枚数</th>
+                    <th class="subtotal">金額</th>
+                    <th class="extra"></th>
+                  </tr>
+                </thead>
+
+                <tbody>
+                  <tr>
+                    <td class="bingo">
+                      <ul class="status_label">
+                        <li class="lb_gre">抽選前</li>
+                      </ul>
+                    </td>
+                    <td class="show" data-label="公演情報">
+                      <div>
+                        <div class="show_no">01</div>
+                        <div>
+                          2024.12.17（火）　東京都:練馬文化センター 大ホール
+                          <aside>開場16:05　開演16:50</aside>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="seat" data-label="席種">一般席</td>
+                    <td class="ticket" data-label="枚数">1 枚</td>
+                    <td class="subtotal" data-label="金額">-----</td>
+                    <td class="extra"></td>
+                  </tr>
+
+                  <tr>
+                    <td class="bingo">
+                      <ul class="status_label">
+                        <li class="lb_gre">抽選前</li>
+                      </ul>
+                    </td>
+                    <td class="show" data-label="公演情報">
+                      <div>
+                        <div class="show_no">02</div>
+                        <div>
+                          2024.12.17（火）　東京都:練馬文化センター 大ホール
+                          <aside>開場18:45　開演19:30</aside>
+                        </div>
+                      </div>
+                    </td>
+                    <td class="seat" data-label="席種">一般席</td>
+                    <td class="ticket" data-label="枚数">1 枚</td>
+                    <td class="subtotal" data-label="金額">-----</td>
+                    <td class="extra"></td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          <div class="dpf__btnwrap flex jc-center">
+            <p class="submit__btn">
+              <button type="button" onclick="location.href='./index.php'" class="input-button form__btn link__btn02">
+                戻る
+              </button>
+            </p>
+          </div>
+        </div>
+      </section>
+
+      <section class="page-bnrarea ps-r" id="page-bnrarea ">
+        <div class="inner ps-r">
+          <ul class="pick__snswrap flex jc-center align-items wow fadeInUp">
+            <li class="pick__sns">
+              <a href="https://twitter.com/ufi_fc" target="_blank" rel="noopener noreferrer"
+                ><img src="/helloproject/images/cmn/ico_X.png" alt="twitter"
+              /></a>
+            </li>
+            <li class="pick__sns">
+              <a href="https://www.instagram.com/hp_officialfanclub/" target="_blank" rel="noopener noreferrer"
+                ><img src="/helloproject/images/cmn/ico_ig.png" alt="instagram"
+              /></a>
+            </li>
+            <li class="pick__sns">
+              <a href="https://www.youtube.com/@UFfanclub" target="_blank" rel="noopener noreferrer"
+                ><img src="/helloproject/images/cmn/ico_yt.png" alt="youtube"
+              /></a>
+            </li>
+          </ul>
+        </div>
+      </section>
+    </main>
+
+    <script language="JavaScript" type="text/javascript">
+      function jpoChk(jpoObj) {
+        var val = jpoObj.value;
+        if (val.length == 1) {
+          if (isNaN(val) == false) {
+            jpoObj.value = '0' + jpoObj.value;
+          }
+        }
+      }
+
+      function reDrawing(frm, action) {
+        frm.action = action;
+        frm.method = 'POST';
+        frm.submit();
+      }
+
+      function submitToken(e) {
+        // 支払方法確認
+        var radioPaymentID = document.getElementsByName('event_payment');
+        var paymentID = 0;
+        for (var i = 0; i < radioPaymentID.length; i++) {
+          // チェックのある支払い方法を取得
+          if (radioPaymentID[i].checked) {
+            paymentID = radioPaymentID[i].value;
+          }
+        }
+
+        var num = document.getElementById('card_number').value;
+        if (!isNaN(num) && paymentID == 4) {
+          if (
+            (num >= 4980056360800000 && num <= 4980056361499999) ||
+            (num >= 4980056186910000 && num <= 4980056190309999) ||
+            (num >= 4980004451600000 && num <= 4980004451699999) ||
+            (num >= 4980057381500000 && num <= 4980057382199999) ||
+            (num >= 4980004458700000 && num <= 4980004458799999) ||
+            num == 0000000000000000
+          ) {
+          } else {
+            alert('UFI カードのみ決済が可能です。');
+            return;
+          }
+        }
+
+        if (paymentID == 4) {
+          if (!document.getElementById('cc-name').value) {
+            alert('クレジットカード名義が未入力です');
+            return;
+          }
+
+          var data = {};
+          data.token_api_key = '27e8b46d-9e2d-4db7-bcd1-4fb33b7ead10';
+          if (document.getElementById('card_number')) {
+            data.card_number = document.getElementById('card_number').value;
+          }
+          if (document.getElementById('cc-exp')) {
+            data.card_expire = document.getElementById('cc-exp').value;
+          }
+          if (document.getElementById('cc-csc')) {
+            data.security_code = document.getElementById('cc-csc').value;
+          }
+          if (document.getElementById('cc-name')) {
+            data.cardholder_name = document.getElementById('cc-name').value;
+          }
+
+          data.lang = 'ja';
+
+          var url = 'https://api3.veritrans.co.jp/4gtoken';
+
+          var xhr = new XMLHttpRequest();
+          xhr.open('POST', url, true);
+          xhr.setRequestHeader('Accept', 'application/json');
+          xhr.setRequestHeader('Content-Type', 'application/json; charset=utf-8');
+          xhr.addEventListener('loadend', function () {
+            if (xhr.status === 0) {
+              alert('トークンサーバーとの接続に失敗しました');
+              return;
+            }
+            var response = JSON.parse(xhr.response);
+
+            if (xhr.status == 200) {
+              document.getElementById('req_card_number').value = response.req_card_number;
+              document.getElementById('token_expire_date').value = response.token_expire_date;
+              document.getElementById('CardExp').value = document.getElementById('cc-exp').value;
+
+              document.getElementById('card_number').value = '';
+              document.getElementById('cc-exp').value = '';
+              document.getElementById('cc-csc').value = '';
+              document.getElementById('cc-name').value = '';
+              document.getElementById('token').value = response.token;
+
+              document.forms['frm_event'].submit();
+            } else {
+              $.post('payment_check.php', function (data) {
+                if (data == 'ng') {
+                  window.location.href = '/';
+                }
+              });
+              alert(response.message);
+            }
+          });
+          xhr.send(JSON.stringify(data));
+        } else if (paymentID == 1) {
+          //var CVSID = document.getElementById('event_payment_cvs').value;
+          var radioCVSID = document.getElementsByName('event_payment_cvs');
+          var CVSID = 0;
+          for (var i = 0; i < radioCVSID.length; i++) {
+            // チェックのある支払い方法を取得
+            if (radioCVSID[i].checked) {
+              CVSID = radioCVSID[i].value;
+            }
+          }
+
+          if (!CVSID) {
+            alert('コンビニエンスストアを選択して下さい。');
+            return;
+          } else {
+            document.forms['frm_event'].submit();
+          }
+          document.forms['frm_event'].submit();
+        } else {
+          alert('支払方法を選択して下さい。');
+        }
+      }
+    </script>
+    <footer class="ps-r">
+      <p class="ft__obj01"></p>
+      <p class="ft__obj02"></p>
+      <p class="ft__obj03"></p>
+      <div class="inner ps-r">
+        <h2 class="ft__logo">
+          <a href="index.html"
+            ><img
+              src="/helloproject/images/cmn/hd_logo.svg"
+              alt="オフィシャルファンクラブWEBサイト HELLO! PROJECT SINCE1998"
+              loading="lazy"
+          /></a>
+        </h2>
+
+        <ul class="ft__topnav ft__nav02 flex jc-center">
+          <li class="ft-topnav__li"><a href="/helloproject/mypage/">マイページ</a></li>
+        </ul>
+
+        <div class="ft__flex flex jc-between">
+          <div class="ft__left">
+            <ul class="ft__nav ft__nav03 flex">
+              <li class="ft-nav__li"><a href="/helloproject/news_list.php">ファンクラブニュース</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/service.php">サービス一覧</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/faq.php">よくあるご質問</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/contact.php">お問合せ</a></li>
+              <li class="ft-nav__li sponly"><a href="/helloproject/information.php">サイト案内</a></li>
+              <li class="ft-nav__li sponly"><a href="/helloproject/terms.php">会員規約</a></li>
+              <li class="ft-nav__li sponly"><a href="/helloproject/privacy.php">個人情報保護方針</a></li>
+              <li class="ft-nav__li sponly"><a href="/helloproject/law.php">特定商取引法</a></li>
+            </ul>
+            <ul class="ft__nav ft__nav04 flex spnone">
+              <li class="ft-nav__li"><a href="/helloproject/information.php">サイト案内</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/terms.php">会員規約</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/privacy.php">個人情報保護方針</a></li>
+              <li class="ft-nav__li"><a href="/helloproject/law.php">特定商取引法</a></li>
+            </ul>
+          </div>
+          <div class="ft__right">
+            <div class="ft__infowrap flex jc-end">
+              <div class="ft__info ft__jasrac flex">
+                <p class="ft__info--logo"><img src="/helloproject/images/cmn/jasrac_logo.png" alt="jasrac" /></p>
+                <p class="ft__info--txt">
+                  JASRAC許諾<br />
+                  第6657568030Y31016号<br />
+                  第6657568031Y45037号<br />
+                  第6657568032Y45037号
+                </p>
+              </div>
+              <div class="ft__info ft__jasrac flex">
+                <p class="ft__info--logo"><img src="/helloproject/images/cmn/nextone_logo.png" alt="nexton" /></p>
+                <p class="ft__info--txt">
+                  NexTone許諾<br />
+                  ID000006322<br />
+                  ID000006514
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+        <p class="ft__notice">
+          当サイトに掲載されているすべてのコンテンツ（文章、写真、画像、動画、バナーなど）
+          の著作権はアップフロントインターナショナルに帰属しています。
+        </p>
+        <p class="ft__copyright"><small>© 1998-2024 UP-FRONT INTERNATIONAL Co.,Ltd.</small></p>
+      </div>
+    </footer>
+
+    <p class="js-pagetop" id="page-top">
+      <a href="#top"><img src="/helloproject/images/cmn/pagetop.png" alt="pagetop" /></a>
+    </p>
+
+    <!-- <script src="/helloproject/js/swiper-bundle.min.js"></script> -->
+    <script type="text/javascript" src="/helloproject/js/slick/slick.min.js"></script>
+    <script src="/helloproject/js/wow.min.js"></script>
+    <script>
+      new WOW().init();
+    </script>
+    <script src="/helloproject/js/modaal.min.js"></script>
+    <script>
+      $('.moddal').modaal({
+        overlay_close: true, //モーダル背景クリック時に閉じるか
+        before_open: function () {
+          // モーダルが開く前に行う動作
+          $('html').css('overflow-y', 'hidden'); /*縦スクロールバーを出さない*/
+        },
+        after_close: function () {
+          // モーダルが閉じた後に行う動作
+          $('html').css('overflow-y', 'scroll'); /*縦スクロールバーを出す*/
+        }
+      });
+    </script>
+    <script src="/helloproject/js/script.js"></script>
+  </body>
+</html>

--- a/expo/features/upfc/scraper/internals/testdata/upfc2/valid-tickets-page.html
+++ b/expo/features/upfc/scraper/internals/testdata/upfc2/valid-tickets-page.html
@@ -1,0 +1,16 @@
+<div>
+  <h4>チケット/イベント</h4>
+  <ul class="mypage_entry_box">
+    <li>
+      <a href="/helloproject/mypage/event_payment.php?@uid=7MUPAfEaTTTRLXZ0">
+        <div class="entry_list_top">
+          <ul class="status_label">
+            <li class="lb_gre">抽選前</li>
+          </ul>
+          <h5>【先々行受付】モーニング娘。'24 FCイベント ～娘。×FAN×Fun！×クリスマス～</h5>
+        </div>
+        <div class="entry_list_btm"></div>
+      </a>
+    </li>
+  </ul>
+</div>

--- a/expo/features/upfc/scraper/internals/testdata/upfc2/valid.expected.json
+++ b/expo/features/upfc/scraper/internals/testdata/upfc2/valid.expected.json
@@ -1,0 +1,77 @@
+[
+  {
+    "name": "【先々行受付】モーニング娘。'24 FCイベント ～娘。×FAN×Fun！×クリスマス～",
+    "site": "helloproject",
+    "applicationID": "7MUPAfEaTTTRLXZ0",
+    "applicationStartDate": "2024-11-08T02:00:00.000Z",
+    "applicationDueDate": "2024-11-12T02:00:00.000Z",
+    "paymentOpenDate": "2024-11-13T02:00:00.000Z",
+    "paymentDueDate": "2024-11-25T02:00:00.000Z",
+    "tickets": [
+      {
+        "status": "抽選前",
+        "num": 1,
+        "venue": "東京都 練馬文化センター",
+        "startAt": "2024-12-17T07:50:00.000Z",
+        "openAt": "2024-12-17T07:05:00.000Z"
+      },
+      {
+        "status": "抽選前",
+        "num": 1,
+        "venue": "東京都 練馬文化センター",
+        "startAt": "2024-12-17T10:30:00.000Z",
+        "openAt": "2024-12-17T09:45:00.000Z"
+      }
+    ]
+  },
+  {
+    "name": "モーニング娘。'24 FCイベント ～娘。×FAN×Fun！×クリスマス～",
+    "site": "helloproject",
+    "applicationID": "Uy8Dz9edPiWk5F4u",
+    "applicationStartDate": "2024-11-08T02:00:00.000Z",
+    "applicationDueDate": "2024-11-12T02:00:00.000Z",
+    "paymentOpenDate": "2024-11-13T02:00:00.000Z",
+    "paymentDueDate": "2024-11-25T02:00:00.000Z",
+    "tickets": []
+  },
+  {
+    "name": "【先々行受付】Hello! Project 2025 Winter Fes. 「各」／「合」",
+    "site": "helloproject",
+    "applicationID": "wSjsyWxBARuW4eqn",
+    "applicationStartDate": "2024-11-08T02:00:00.000Z",
+    "applicationDueDate": "2024-11-12T02:00:00.000Z",
+    "paymentOpenDate": "2024-11-13T02:00:00.000Z",
+    "paymentDueDate": "2024-11-25T02:00:00.000Z",
+    "tickets": []
+  },
+  {
+    "name": "Hello! Project 2025 Winter Fes. 「各」／「合」",
+    "site": "helloproject",
+    "applicationID": "aG1D8uYAQuqRIN7U",
+    "applicationStartDate": "2024-11-08T02:00:00.000Z",
+    "applicationDueDate": "2024-11-12T02:00:00.000Z",
+    "paymentOpenDate": "2024-11-13T02:00:00.000Z",
+    "paymentDueDate": "2024-11-25T02:00:00.000Z",
+    "tickets": []
+  },
+  {
+    "name": "アンジュルム 川名凜バースデーイベント2024 in 名古屋",
+    "site": "helloproject",
+    "applicationID": "Dppvx3ybTgpPFSFI",
+    "applicationStartDate": "2024-11-08T02:00:00.000Z",
+    "applicationDueDate": "2024-11-12T02:00:00.000Z",
+    "paymentOpenDate": "2024-11-13T02:00:00.000Z",
+    "paymentDueDate": "2024-11-25T02:00:00.000Z",
+    "tickets": []
+  },
+  {
+    "name": "【当日券予約】竹内朱莉バースデーイベント2024～Ⅱ～",
+    "site": "helloproject",
+    "applicationID": "ThqFqmVI6ddtIz7m",
+    "applicationStartDate": "2024-11-08T02:00:00.000Z",
+    "applicationDueDate": "2024-11-12T02:00:00.000Z",
+    "paymentOpenDate": "2024-11-13T02:00:00.000Z",
+    "paymentDueDate": "2024-11-25T02:00:00.000Z",
+    "tickets": []
+  }
+]

--- a/expo/features/upfc/scraper/internals/testdata/valid-redirect.html
+++ b/expo/features/upfc/scraper/internals/testdata/valid-redirect.html
@@ -1,5 +1,7 @@
-﻿<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="ja" style="overflow-x:hidden;">
-<head>
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
-<META HTTP-EQUIV=Refresh basetarget=_top CONTENT=0;URL='index.php'>
+﻿<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="ja" style="overflow-x: hidden">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Refresh" basetarget="_top" content="0;URL=mypage01.php" />
+  </head>
+</html>

--- a/expo/features/upfc/scraper/internals/types.ts
+++ b/expo/features/upfc/scraper/internals/types.ts
@@ -27,7 +27,7 @@ export type UPFCEventTicket = {
 /**
  * a enum to represent a ticket application status.
  */
-export type UPFCTicketApplicationStatus = '申込済' | '入金待' | '入金済' | '落選' | '入金忘' | '不明';
+export type UPFCTicketApplicationStatus = '抽選前' | '申込済' | '入金待' | '入金済' | '落選' | '入金忘' | '不明';
 
 /**
  * a enum to represent a site of up-fc.jp
@@ -93,5 +93,7 @@ export interface UPFCFetcher {
   postCredential(username: string, password: string, site: UPFCSite): Promise<string>;
   fetchEventApplicationsHtml(site: UPFCSite): Promise<string>;
   fetchExecEventApplicationsHtml(site: UPFCSite): Promise<string>;
+  fetchEventApplicationDetailHtml(site: UPFCSite, id: string): Promise<string>;
   fetchTicketsHtml(site: UPFCSite): Promise<string>;
+  fetchTicketDetailHtml(site: UPFCSite, id: string): Promise<string>;
 }

--- a/expo/package.json
+++ b/expo/package.json
@@ -71,6 +71,7 @@
     "expo-updates": "~0.25.17",
     "i18n-js": "^4.3.2",
     "jsdom-jscore-rn": "^0.1.8",
+    "node-html-parser": "^6.1.13",
     "path": "^0.12.7",
     "react": "18.2.0",
     "react-content-loader": "^7.0.2",

--- a/expo/yarn.lock
+++ b/expo/yarn.lock
@@ -8319,7 +8319,7 @@ hast-util-to-string@^3.0.0:
   dependencies:
     "@types/hast" "^3.0.0"
 
-he@^1.2.0:
+he@1.2.0, he@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
@@ -10657,6 +10657,14 @@ node-forge@1.3.1, node-forge@^1, node-forge@^1.2.1, node-forge@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-1.3.1.tgz#be8da2af243b2417d5f646a770663a92b7e9ded3"
   integrity sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==
+
+node-html-parser@^6.1.13:
+  version "6.1.13"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-6.1.13.tgz#a1df799b83df5c6743fcd92740ba14682083b7e4"
+  integrity sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==
+  dependencies:
+    css-select "^5.1.0"
+    he "1.2.0"
 
 node-int64@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
**Summary**

we adds upfc.jp support to the scraper though we haven't confimed the whole process of applications.

- we now deprecate jsdom and use node-html-parser instead for the new scraper.
- UPFCSiteScraper is still maintained to keep tracking for past events.

**Test**

- jest
- expo

**Issue**

- N/A