### PR TITLE
[expo] add consent gate for policies.

### DIFF
--- a/expo/features/app/__snapshots__/index.test.tsx.snap
+++ b/expo/features/app/__snapshots__/index.test.tsx.snap
@@ -78,8 +78,7 @@ exports[`app AppUpdateBanner show banner 1`] = `
       </Text>
     </View>
   </View>,
-  <RNCSafeAreaProvider
-    onInsetsChange={[Function]}
+  <View
     style={
       [
         {
@@ -194,6 +193,6 @@ exports[`app AppUpdateBanner show banner 1`] = `
         />
       </RNSScreen>
     </RNSScreenStack>
-  </RNCSafeAreaProvider>,
+  </View>,
 ]
 `;

--- a/expo/features/app/index.test.tsx
+++ b/expo/features/app/index.test.tsx
@@ -7,8 +7,16 @@ import { Text } from 'react-native';
 
 import { AppRoot } from './';
 import AppConfigModal from './internals/AppConfigModal';
-import { useAppConfig } from './settings';
+import { SettingsUserConfigDefault, useAppConfig } from './settings';
 import { clearSettings } from './settings/testhelper';
+
+const userConfig = {
+  ...SettingsUserConfigDefault,
+  completeOnboarding: true,
+  consentOnToS: true,
+  consentOnPrivacy: true,
+  consentOnUPFCDataPolicy: true
+};
 
 beforeEach(async () => {
   await clearSettings();
@@ -111,6 +119,7 @@ describe('app', () => {
             username: 'risa',
             accessToken: 'token'
           }}
+          userConfig={userConfig}
         />
       );
       await act(() => {});
@@ -121,7 +130,7 @@ describe('app', () => {
     });
 
     test('guest', async () => {
-      const content = await render(<AppRoot screens={[TestScreen]} />);
+      const content = await render(<AppRoot screens={[TestScreen]} userConfig={userConfig} />);
       await act(() => {});
       expect(content.queryByTestId('UserRoot.Loading')).toBeNull();
       expect(content.getByTestId('AppRootGuest')).toBeTruthy();

--- a/expo/features/app/settings/index.tsx
+++ b/expo/features/app/settings/index.tsx
@@ -7,7 +7,7 @@ import SettingsCurrentUser, { CurrentUser } from './internals/SettingsCurrentUse
 import SettingsList from './internals/SettingsList';
 import Provider, { useSettings } from './internals/SettingsProvider';
 import SettingsUPFCConfig, { UPFCConfig } from './internals/SettingsUPFCConfig';
-import SettingsUserConfig, { UserConfig } from './internals/SettingsUserConfig';
+import SettingsUserConfig, { UserConfig, SettingsUserConfigDefault } from './internals/SettingsUserConfig';
 
 export type SettingsProviderProps = {
   appConfig?: AppConfig;
@@ -161,3 +161,5 @@ export function useCurrentUserUpdator() {
     [updator]
   );
 }
+
+export { SettingsUserConfigDefault };

--- a/expo/features/app/user/__snapshots__/index.test.tsx.snap
+++ b/expo/features/app/user/__snapshots__/index.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`user should return Me object 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -117,12 +116,11 @@ exports[`user should return Me object 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;
 
 exports[`user useHelloProject 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -330,5 +328,5 @@ yume_soma
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/artist/__snapshots__/index.test.tsx.snap
+++ b/expo/features/artist/__snapshots__/index.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`artist ArtistMemberFollowIcon following 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -118,12 +117,11 @@ exports[`artist ArtistMemberFollowIcon following 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;
 
 exports[`artist ArtistMemberFollowIcon not following 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -232,12 +230,11 @@ exports[`artist ArtistMemberFollowIcon not following 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;
 
 exports[`artist ArtistMemberIcon icon 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -405,5 +402,5 @@ exports[`artist ArtistMemberIcon icon 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/common/card/internals/__snapshots__/Card.test.tsx.snap
+++ b/expo/features/common/card/internals/__snapshots__/Card.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Card Basic 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -203,12 +202,11 @@ exports[`Card Basic 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;
 
 exports[`Card SubHeader 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -432,5 +430,5 @@ exports[`Card SubHeader 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/common/card/internals/__snapshots__/CardSkelton.test.tsx.snap
+++ b/expo/features/common/card/internals/__snapshots__/CardSkelton.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CardSkelton Basic 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -348,5 +347,5 @@ exports[`CardSkelton Basic 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/common/internals/ConsentGate.tsx
+++ b/expo/features/common/internals/ConsentGate.tsx
@@ -1,4 +1,5 @@
 import { useThemeColor } from '@hpapp/features/app/theme';
+import { FontSize } from '@hpapp/features/common/constants';
 import { t } from '@hpapp/system/i18n';
 import { Header, Button } from '@rneui/themed';
 import React from 'react';
@@ -33,10 +34,12 @@ export default function ConsentGate({
     <View style={{ flex: 1, paddingBottom: insets.bottom }}>
       {showHeader && (
         <Header
-          placement="left"
+          placement="center"
           centerComponent={{
             text: title,
             style: {
+              fontSize: FontSize.Large,
+              fontWeight: 'bold',
               color: contrastColor
             }
           }}

--- a/expo/features/common/internals/__snapshots__/AmebloIcon.test.tsx.snap
+++ b/expo/features/common/internals/__snapshots__/AmebloIcon.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AmebloIcon Basic 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -247,5 +246,5 @@ exports[`AmebloIcon Basic 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/common/internals/__snapshots__/AssetIcon.test.tsx.snap
+++ b/expo/features/common/internals/__snapshots__/AssetIcon.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`AssetIcon Basic 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -247,5 +246,5 @@ exports[`AssetIcon Basic 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/common/internals/__snapshots__/CalendarDateIcon.test.tsx.snap
+++ b/expo/features/common/internals/__snapshots__/CalendarDateIcon.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CalendarDateIcon.stories Basic 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -180,12 +179,11 @@ exports[`CalendarDateIcon.stories Basic 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;
 
 exports[`CalendarDateIcon.stories InvalidDate 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -340,5 +338,5 @@ exports[`CalendarDateIcon.stories InvalidDate 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/common/internals/__snapshots__/ExternalImage.test.tsx.snap
+++ b/expo/features/common/internals/__snapshots__/ExternalImage.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ExternalImage Basic 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -141,5 +140,5 @@ exports[`ExternalImage Basic 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/home/__snapshots__/index.test.tsx.snap
+++ b/expo/features/home/__snapshots__/index.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`home HomeScreen 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -11321,7 +11320,7 @@ fragment FeedListItemViewHistoryIconFragment on HPFeedItem {
                               {
                                 "justifyContent": "center",
                                 "marginHorizontal": 16,
-                                "maxWidth": 718,
+                                "maxWidth": 288,
                               }
                             }
                           >
@@ -12084,5 +12083,5 @@ fragment FeedListItemViewHistoryIconFragment on HPFeedItem {
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/home/internals/artist/__snapshots__/HomeTabArtist.test.tsx.snap
+++ b/expo/features/home/internals/artist/__snapshots__/HomeTabArtist.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HomeTabArtist tab 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -38125,5 +38124,5 @@ exports[`HomeTabArtist tab 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/home/internals/menu/__snapshots__/HomeTabMenuVersionSignature.test.tsx.snap
+++ b/expo/features/home/internals/menu/__snapshots__/HomeTabMenuVersionSignature.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HomeTabMenuVersionSignature Basic 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -206,5 +205,5 @@ exports[`HomeTabMenuVersionSignature Basic 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/home/internals/menu/__snapshots__/MenuTab.test.tsx.snap
+++ b/expo/features/home/internals/menu/__snapshots__/MenuTab.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`SettingsTab render 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -1318,5 +1317,5 @@ exports[`SettingsTab render 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/home/internals/upfc/__snapshots__/HomeTabUPFC.test.tsx.snap
+++ b/expo/features/home/internals/upfc/__snapshots__/HomeTabUPFC.test.tsx.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`HomeTabUPFC render UPFCErrorBox if settings is not configured 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -213,12 +212,11 @@ exports[`HomeTabUPFC render UPFCErrorBox if settings is not configured 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;
 
 exports[`HomeTabUPFC render list if settings is configured 1`] = `
-<RNCSafeAreaProvider
-  onInsetsChange={[Function]}
+<View
   style={
     [
       {
@@ -4737,5 +4735,5 @@ exports[`HomeTabUPFC render list if settings is configured 1`] = `
       />
     </RNSScreen>
   </RNSScreenStack>
-</RNCSafeAreaProvider>
+</View>
 `;

--- a/expo/features/settings/SettingsDevOnlyScreen.tsx
+++ b/expo/features/settings/SettingsDevOnlyScreen.tsx
@@ -3,6 +3,7 @@ import { defineScreen } from '@hpapp/features/common/stack';
 import { Divider } from '@rneui/themed';
 
 import SettingsDevOnlyListItem from './internals/SettingsDevOnlyListItem';
+import SettingsUserConfigForm from './internals/SettingsUserConfigForm';
 
 export default defineScreen('/settings/devonly/', function DevOnlySettingsScreen() {
   const user = useCurrentUser();
@@ -18,6 +19,7 @@ export default defineScreen('/settings/devonly/', function DevOnlySettingsScreen
         displayValue={user!.accessToken.substring(0, 4) + '****'}
       />
       <Divider />
+      <SettingsUserConfigForm />
       <SettingsDevOnlyListItem name="Local User Config" value={JSON.stringify(userConfig, null, 2)} />
       <Divider />
       <SettingsDevOnlyListItem name="Local App  Config" value={JSON.stringify(appConfig, null, 2)} />

--- a/expo/features/settings/internals/SettingsUserConfigForm.tsx
+++ b/expo/features/settings/internals/SettingsUserConfigForm.tsx
@@ -1,0 +1,96 @@
+import { useUserConfig, useUserConfigUpdator } from '@hpapp/features/app/settings';
+import { Text } from '@hpapp/features/common';
+import { FontSize, Spacing } from '@hpapp/features/common/constants';
+import { Switch } from '@rneui/themed';
+import { StyleSheet, View } from 'react-native';
+
+export default function SettingsUserConfigForm() {
+  const userConfig = useUserConfig()!;
+  const userConfigUpdate = useUserConfigUpdator();
+
+  return (
+    <>
+      <View style={[styles.inputGroup, styles.switchContainer]}>
+        <Text style={styles.label}>completeOnboarding</Text>
+        <Switch
+          value={userConfig.completeOnboarding}
+          onValueChange={() => {
+            userConfigUpdate({ ...userConfig, completeOnboarding: !userConfig.completeOnboarding });
+          }}
+        />
+      </View>
+      <View style={[styles.inputGroup, styles.switchContainer]}>
+        <Text style={styles.label}>consentOnToS</Text>
+        <Switch
+          value={userConfig.consentOnToS}
+          onValueChange={() => {
+            userConfigUpdate({ ...userConfig, consentOnToS: !userConfig.consentOnToS });
+          }}
+        />
+      </View>
+      <View style={[styles.inputGroup, styles.switchContainer]}>
+        <Text style={styles.label}>consentOnPrivacy</Text>
+        <Switch
+          value={userConfig.consentOnPrivacy}
+          onValueChange={() => {
+            userConfigUpdate({ ...userConfig, consentOnPrivacy: !userConfig.consentOnPrivacy });
+          }}
+        />
+      </View>
+      <View style={[styles.inputGroup, styles.switchContainer]}>
+        <Text style={styles.label}>consentOnUPFCDataPolicy</Text>
+        <Switch
+          value={userConfig.consentOnUPFCDataPolicy}
+          onValueChange={() => {
+            userConfigUpdate({ ...userConfig, consentOnUPFCDataPolicy: !userConfig.consentOnUPFCDataPolicy });
+          }}
+        />
+      </View>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  content: {
+    flex: 1,
+    flexDirection: 'column'
+  },
+  form: {
+    flex: 1,
+    flexGrow: 1
+  },
+  label: {
+    paddingLeft: Spacing.Small,
+    paddingRight: Spacing.Small
+  },
+  default: {
+    fontStyle: 'italic',
+    fontSize: FontSize.XSmall
+  },
+  inputGroup: {
+    marginTop: Spacing.XSmall
+  },
+  switchContainer: {
+    alignItems: 'center',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    marginBottom: Spacing.Small
+  },
+  input: {},
+  inputError: {},
+  footer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between'
+  },
+  buttonGroup: {
+    marginTop: Spacing.Small,
+    width: '100%',
+    flexDirection: 'row',
+    justifyContent: 'space-evenly'
+  },
+  button: {
+    flexGrow: 1,
+    paddingLeft: Spacing.Small,
+    paddingRight: Spacing.Small
+  }
+});

--- a/expo/features/testhelper/internals/jest.tsx
+++ b/expo/features/testhelper/internals/jest.tsx
@@ -1,10 +1,18 @@
-import { SettingsProviderProps } from '@hpapp/features/app/settings';
+import { SettingsProviderProps, SettingsUserConfigDefault } from '@hpapp/features/app/settings';
 import { renderThemeProvider } from '@hpapp/features/app/theme/testhelper';
 import * as Stack from '@hpapp/features/common/stack';
 import { screen, act, waitForElementToBeRemoved } from '@testing-library/react-native';
 import { AppRoot } from 'features/app';
 import React from 'react';
 import { Text } from 'react-native';
+
+const userConfig = {
+  ...SettingsUserConfigDefault,
+  completeOnboarding: true,
+  consentOnToS: true,
+  consentOnPrivacy: true,
+  consentOnUPFCDataPolicy: true
+};
 
 export async function renderUserScreen(screen: Stack.Screen<Stack.ScreenParams>, props: SettingsProviderProps = {}) {
   const content = await renderThemeProvider(<AppRoot screens={[screen]} />, {
@@ -13,6 +21,7 @@ export async function renderUserScreen(screen: Stack.Screen<Stack.ScreenParams>,
       username: 'risa',
       accessToken: 'token'
     },
+    userConfig,
     ...props
   });
   expect(content.getByTestId('UserRoot.Loading')).toBeTruthy();
@@ -37,6 +46,7 @@ export async function renderGuestComponent(component: React.ReactElement, props:
     return <Text>DummyUserRoot</Text>;
   });
   const content = await renderThemeProvider(<AppRoot screens={[screen]} />, {
+    userConfig,
     ...props,
     currentUser: undefined
   });

--- a/expo/jest.setup.tsx
+++ b/expo/jest.setup.tsx
@@ -1,3 +1,5 @@
+import mockSafeAreaContext from 'react-native-safe-area-context/jest/mock';
+
 jest.mock('expo-asset', () => ({
   useAssets: jest.fn((moduleIds: number | number[]) => {
     if (typeof moduleIds === 'number') {
@@ -148,6 +150,8 @@ jest.mock('@react-native-firebase/auth', () => {
   };
   return module;
 });
+
+jest.mock('react-native-safe-area-context', () => mockSafeAreaContext);
 
 jest.mock('react-native-share', () => ({
   default: jest.fn()


### PR DESCRIPTION
**Summary**

tos and privacy policy are now shown in a consent gate before users starts using the app

**Test**

- yarn test

**Issue**

- N/A