### PR TITLE
[expo][3.0-release-test] fix upfc loading logic

### DIFF
--- a/expo/features/feed/internals/FeedContext.tsx
+++ b/expo/features/feed/internals/FeedContext.tsx
@@ -106,13 +106,6 @@ function createFeedContext(): [(props: FeedContextProviderProps) => React.JSX.El
     const reload = () => {
       setFetchCount(fetchCount + 1);
     };
-    if (data === null) {
-      return (
-        <FeedContextRenderer data={null} isLoading={isLoading} reload={reload}>
-          {children}
-        </FeedContextRenderer>
-      );
-    }
     return (
       <FeedContextPaginationRenderer fragment={data} isLoading={isLoading} reload={reload}>
         {children}
@@ -128,11 +121,11 @@ function createFeedContext(): [(props: FeedContextProviderProps) => React.JSX.El
     children: React.ReactElement;
     isLoading: boolean;
     reload: () => void;
-    fragment: FeedContextQuery$data;
+    fragment: FeedContextQuery$data | null;
   }) {
     const data = usePaginationFragment<FeedContextQueryFragmentQuery, FeedContextQuery_helloproject_query_feed$key>(
       FeedContextQueryFragmentGraphQL,
-      fragment.helloproject!
+      fragment?.helloproject ?? null
     );
     return (
       <FeedContextRenderer data={data} isLoading={isLoading} reload={reload}>
@@ -153,12 +146,12 @@ function createFeedContext(): [(props: FeedContextProviderProps) => React.JSX.El
     data: usePaginationFragmentHookType<
       FeedContextQueryFragmentQuery,
       FeedContextQuery_helloproject_query_feed$key,
-      FeedContextQuery_helloproject_query_feed$data
-    > | null;
+      FeedContextQuery_helloproject_query_feed$data | undefined | null
+    >;
   }) {
     const ctxValue = useMemo(() => {
       return {
-        data: data?.data.feed?.edges?.map((e) => e!.node!) ?? null,
+        data: data?.data?.feed?.edges?.map((e) => e!.node!) ?? null,
         isLoading,
         hasNext: data?.hasNext ?? false,
         reload,

--- a/expo/features/home/internals/upfc/HomeTabUPFC.tsx
+++ b/expo/features/home/internals/upfc/HomeTabUPFC.tsx
@@ -1,11 +1,11 @@
 import { View, StyleSheet } from 'react-native';
 
-import UPFCCurentApplicationList from './HomeTabUPFCCurrentApplicationList';
+import HomeTabUPFCCurrentApplicationList from './HomeTabUPFCCurrentApplicationList';
 
 export default function HomeTabUPFC() {
   return (
     <View style={styles.container}>
-      <UPFCCurentApplicationList />
+      <HomeTabUPFCCurrentApplicationList />
     </View>
   );
 }

--- a/expo/system/cache/index.ts
+++ b/expo/system/cache/index.ts
@@ -16,24 +16,31 @@ async function defaultLoadFn<T>(value: string): Promise<T | undefined> {
 const BaseCacheDir = [FileSystem.cacheDirectory, 'fscache'].join('/');
 
 export type CacheOptions<T> = {
-  key: string;
+  key?: string;
+  dynamicCacheKey?: () => Promise<string>;
   saveFn?: (data: T) => Promise<string>;
   loadFn?: (data: string) => Promise<T | undefined>;
 };
 
 export class FileSystemCache<T> {
-  key: string;
+  key?: string;
+  dynamicCacheKey?: () => Promise<string>;
   saveFn: (data: any) => Promise<string>;
   loadFn: (value: string) => Promise<T | undefined>;
 
   constructor(options: CacheOptions<T>) {
     this.key = options.key;
+    this.dynamicCacheKey = options.dynamicCacheKey;
     this.saveFn = options?.saveFn ?? defaultSaveFn;
     this.loadFn = options?.loadFn ?? defaultLoadFn;
   }
 
   public async save(data: T): Promise<void> {
-    const cacheFilePath = [BaseCacheDir, this.key].join('/');
+    let key = this.key;
+    if (this.dynamicCacheKey !== undefined) {
+      key = await this.dynamicCacheKey();
+    }
+    const cacheFilePath = [BaseCacheDir, key].join('/');
     try {
       const dirInfo = await FileSystem.getInfoAsync(BaseCacheDir);
       if (!dirInfo.exists) {
@@ -42,22 +49,41 @@ export class FileSystemCache<T> {
       const str = await this.saveFn(data);
       await FileSystem.writeAsStringAsync(cacheFilePath, str);
       logging.Info('system.cache.FileSystemCache', 'save', {
-        key: this.key
+        key
       });
     } catch (e) {
       logging.Error('system.cache.FileSystemCache', 'save error', {
-        key: this.key,
+        key,
         error: e
       });
     }
   }
 
+  public async clear(): Promise<void> {
+    let key = this.key;
+    if (this.dynamicCacheKey !== undefined) {
+      key = await this.dynamicCacheKey();
+    }
+    const cacheFilePath = [BaseCacheDir, key].join('/');
+    await FileSystem.deleteAsync(cacheFilePath, {
+      idempotent: true
+    });
+    logging.Info('system.cache.FileSystemCache', 'clear', {
+      key
+    });
+  }
+
   public async load(): Promise<T | undefined> {
-    const cacheFilePath = [BaseCacheDir, this.key].join('/');
+    let key = this.key;
+    if (this.dynamicCacheKey !== undefined) {
+      key = await this.dynamicCacheKey();
+    }
+
+    const cacheFilePath = [BaseCacheDir, key].join('/');
     const fileInfo = await FileSystem.getInfoAsync(cacheFilePath);
     if (!fileInfo.exists) {
       logging.Info('system.cache.FileSystemCache', 'miss', {
-        key: this.key
+        key
       });
       return undefined;
     }
@@ -65,12 +91,12 @@ export class FileSystemCache<T> {
       const str = await FileSystem.readAsStringAsync(cacheFilePath);
       const data = await this.loadFn(str);
       logging.Info('system.cache.FileSystemCache', 'load', {
-        key: this.key
+        key
       });
       return data;
     } catch (e) {
       logging.Error('system.cache.FileSystemCache', 'error', {
-        key: this.key,
+        key,
         error: e
       });
       return undefined;


### PR DESCRIPTION
**Summary**

- fix FeedContextProvider avoid mount/unmount while loading the data.
- implement dynamicCacheKey to discard a cache with old configuration easily. Note that the cache with old configuration will not be removed from the storage but it should be fine as there are the limited number of patterns that users use as a cache key.
- fix parallel loading issue between helloproject and mline where the cookies are shared under the same domain.

**Test**

- expo

**Issue**

- N/A