### PR TITLE
[github] streamline build and submit

### DIFF
--- a/.github/workflows/eas-build.yml
+++ b/.github/workflows/eas-build.yml
@@ -40,3 +40,33 @@ jobs:
         env:
           HPAPP_CONFIG_NAME: ${{inputs.config}}
           HPAPP_CONFIG_PLATFORM: ${{inputs.platform}}
+  submit:
+    if: ${{inputs.platform}} == 'prod'
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: eas-submission
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+          cache: "yarn"
+          cache-dependency-path: "expo/package.json"
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: 5.4.0
+          token: ${{ secrets.EXPO_TOKEN }}
+      - name: Extract AppStoreKey.p8 file.
+        run: cd expo && envsubst < config/prod/AppStoreKey.p8.env > config/prod/AppStoreKey.p8
+        env:
+          APPLE_APP_STORE_KEY_P8: ${{ secrets.APPLE_APP_STORE_KEY_P8 }}
+      - name: Extract eas.json.
+        run: cd expo && envsubst < config/prod/eas-submission.json.env > eas.json
+        env:
+          EAS_JSON: ${{ secrets.EAS_JSON }}
+      - run: cd expo && yarn install
+      - run: cd expo && yarn eas submit --platform ios --profile prod --latest --non-interactive
+        env:
+          EXPO_APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.EXPO_APPLE_APP_SPECIFIC_PASSWORD }}
+          HPAPP_CONFIG_NAME: prod


### PR DESCRIPTION
**Summary**

we want to submit ios as soon as prod build is ready.

**Test**

- github workflow

**Issue**

- N/A