### PR TITLE
[expo][3.0-release-test] fix asset path

### DIFF
--- a/expo/features/app/internals/AppRootGuest.tsx
+++ b/expo/features/app/internals/AppRootGuest.tsx
@@ -6,7 +6,7 @@ import { View, StyleSheet, Image } from 'react-native';
 export default function AppRootGuest() {
   const appConfig = useAppConfig();
   const LoginContainer = appConfig.useLocalAuth ? AuthLocalLoginContainer : AuthFirebaseLoginContainer;
-  const [loaded] = useAssets([require('@hpapp/assets/icon.png'), require('@hpapp/assets/splash.png')]);
+  const [loaded] = useAssets([require('assets/icon.png'), require('assets/splash.png')]);
   if (!loaded) {
     return <></>;
   }


### PR DESCRIPTION
**Summary**

This is a fix for the production app.

it seems we don't need @hpapp prefix when use useAssets()

**Test**

- need to test on the testflight

**Issue**

- N/A