### PR TITLE
[expo][3.0-release-test] fix assets and udate banner

### DIFF
--- a/expo/assets/translations.json
+++ b/expo/assets/translations.json
@@ -41,7 +41,7 @@
   "something went wrong.": {
     "ja": "エラーが発生しました。"
   },
-  "Update is available. Tap to install.": {
+  "Update is available - Tap to install.": {
     "ja": "アップデートが利用可能です。タップしてインストール。"
   },
   "Updating...": {

--- a/expo/features/app/__snapshots__/index.test.tsx.snap
+++ b/expo/features/app/__snapshots__/index.test.tsx.snap
@@ -3,82 +3,6 @@
 exports[`app AppUpdateBanner show banner 1`] = `
 [
   <View
-    accessibilityState={
-      {
-        "busy": undefined,
-        "checked": undefined,
-        "disabled": false,
-        "expanded": undefined,
-        "selected": undefined,
-      }
-    }
-    accessibilityValue={
-      {
-        "max": undefined,
-        "min": undefined,
-        "now": undefined,
-        "text": undefined,
-      }
-    }
-    accessible={true}
-    collapsable={false}
-    focusable={true}
-    onClick={[Function]}
-    onResponderGrant={[Function]}
-    onResponderMove={[Function]}
-    onResponderRelease={[Function]}
-    onResponderTerminate={[Function]}
-    onResponderTerminationRequest={[Function]}
-    onStartShouldSetResponder={[Function]}
-    style={
-      {
-        "opacity": 1,
-      }
-    }
-    testID="AppUpdateBanner"
-  >
-    <View
-      style={
-        [
-          {
-            "alignItems": "center",
-            "flexDirection": "column",
-            "justifyContent": "center",
-            "padding": 12,
-          },
-          {
-            "backgroundColor": "#faad14",
-            "paddingTop": 0,
-          },
-        ]
-      }
-    >
-      <Text
-        style={
-          [
-            {
-              "color": "black",
-            },
-            {
-              "fontSize": 14,
-            },
-            [
-              {
-                "fontSize": 14,
-                "textAlign": "center",
-              },
-              {
-                "color": "#ffffff",
-              },
-            ],
-          ]
-        }
-      >
-        Update is available. Tap to install.
-      </Text>
-    </View>
-  </View>,
-  <View
     style={
       [
         {
@@ -193,6 +117,85 @@ exports[`app AppUpdateBanner show banner 1`] = `
         />
       </RNSScreen>
     </RNSScreenStack>
+  </View>,
+  <View
+    accessibilityState={
+      {
+        "busy": undefined,
+        "checked": undefined,
+        "disabled": false,
+        "expanded": undefined,
+        "selected": undefined,
+      }
+    }
+    accessibilityValue={
+      {
+        "max": undefined,
+        "min": undefined,
+        "now": undefined,
+        "text": undefined,
+      }
+    }
+    accessible={true}
+    collapsable={false}
+    focusable={true}
+    onClick={[Function]}
+    onResponderGrant={[Function]}
+    onResponderMove={[Function]}
+    onResponderRelease={[Function]}
+    onResponderTerminate={[Function]}
+    onResponderTerminationRequest={[Function]}
+    onStartShouldSetResponder={[Function]}
+    style={
+      {
+        "opacity": 1,
+      }
+    }
+    testID="AppUpdateBanner"
+  >
+    <View
+      style={
+        [
+          {
+            "alignItems": "center",
+            "flexDirection": "column",
+            "justifyContent": "center",
+            "padding": 12,
+            "position": "absolute",
+            "top": -1334,
+            "width": "100%",
+          },
+          {
+            "backgroundColor": "#faad14",
+            "paddingTop": 0,
+          },
+        ]
+      }
+    >
+      <Text
+        style={
+          [
+            {
+              "color": "black",
+            },
+            {
+              "fontSize": 14,
+            },
+            [
+              {
+                "fontSize": 14,
+                "textAlign": "center",
+              },
+              {
+                "color": "#ffffff",
+              },
+            ],
+          ]
+        }
+      >
+        アップデートが利用可能です。タップしてインストール。
+      </Text>
+    </View>
   </View>,
 ]
 `;

--- a/expo/features/app/index.tsx
+++ b/expo/features/app/index.tsx
@@ -15,8 +15,8 @@ export function AppRoot({ screens, ...props }: AppRootProps) {
       <ThemeProvider {...props}>
         <AppRelayProvider>
           <LocalMediaManagerProvider name={maybeDev() ? 'hellofanapp-dev' : 'hellofanapp'}>
-            <AppUpdateBanner />
             <Root screens={screens} />
+            <AppUpdateBanner />
           </LocalMediaManagerProvider>
         </AppRelayProvider>
       </ThemeProvider>

--- a/expo/features/app/internals/AppRootGuest.tsx
+++ b/expo/features/app/internals/AppRootGuest.tsx
@@ -16,7 +16,7 @@ export default function AppRootGuest() {
       <View style={styles.container}>
         <Image
           source={{
-            uri: icon.uri!,
+            uri: icon.localUri ?? icon.uri,
             height: icon.height!,
             width: icon.width!
           }}

--- a/expo/features/app/internals/AppUpdateBanner.tsx
+++ b/expo/features/app/internals/AppUpdateBanner.tsx
@@ -1,10 +1,11 @@
 import { useThemeColor } from '@hpapp/features/app/theme';
 import { Text } from '@hpapp/features/common';
 import { FontSize, Spacing } from '@hpapp/features/common/constants';
+import { t } from '@hpapp/system/i18n';
 import Constants from 'expo-constants';
 import * as Updates from 'expo-updates';
 import { useState, useEffect } from 'react';
-import { AppState, AppStateStatus, TouchableOpacity, StyleSheet, View } from 'react-native';
+import { AppState, AppStateStatus, TouchableOpacity, StyleSheet, View, Dimensions } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as logging from 'system/logging';
 
@@ -83,7 +84,7 @@ export default function AppUpdateBanner({
     return null;
   }
 
-  const text = state.isUpdating ? updateInProgressText : updateAvaiableText;
+  const text = state.isUpdating ? t('Updating...') : t('Update is available - Tap to install.');
   return (
     <TouchableOpacity
       testID="AppUpdateBanner"
@@ -112,8 +113,13 @@ export default function AppUpdateBanner({
   );
 }
 
+const height = Dimensions.get('window').height;
+
 const styles = StyleSheet.create({
   container: {
+    position: 'absolute',
+    top: -1 * height,
+    width: '100%',
     flexDirection: 'column',
     justifyContent: 'center',
     alignItems: 'center',

--- a/expo/package.json
+++ b/expo/package.json
@@ -122,6 +122,7 @@
     "@types/async-lock": "^1.4.1",
     "@types/jest": "^29.5.1",
     "@types/react": "~18.2.79",
+    "@types/react-navigation": "^3.4.0",
     "@types/react-relay": "^16.0.6",
     "babel-loader": "^8.3.0",
     "babel-plugin-module-resolver": "^5.0.0",

--- a/expo/yarn.lock
+++ b/expo/yarn.lock
@@ -3759,6 +3759,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-navigation@^3.4.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@types/react-navigation/-/react-navigation-3.4.0.tgz#d610d13c9162312079a8ca102660143f07432cbf"
+  integrity sha512-Y7F5zU8BTBK8tEOvUqgvwvPZ7+9vnc2UI1vHwJ/9ZJG98TntNv04GWa6lrn4MA4149pqw6cyNw/V49Yd2osAFQ==
+  dependencies:
+    react-navigation "*"
+
 "@types/react-relay@^16.0.6":
   version "16.0.6"
   resolved "https://registry.yarnpkg.com/@types/react-relay/-/react-relay-16.0.6.tgz#afc467fab89dc4c96fb1424f84b869750f5c42f2"
@@ -11002,6 +11009,11 @@ react-native@0.74.5:
     whatwg-fetch "^3.0.0"
     ws "^6.2.2"
     yargs "^17.6.2"
+
+react-navigation@*:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/react-navigation/-/react-navigation-5.0.0.tgz#a7dd98a6148ba997834ebcf5a5073bdb3d4f4eb3"
+  integrity sha512-ACTzjc4L1ik7rJ092ZhIELBJ/pnoLgRIqWHSKcYcaBASxyjJCgBEDIV5s585HBj55tw25YwNdlj3+d4B4MYWDg==
 
 react-refresh@^0.14.0, react-refresh@^0.14.2:
   version "0.14.2"


### PR DESCRIPTION
**Summary**

- assets.uri is not available in production, need to use localUri.
- update banner has to be located after Stack to make it overlay.

**Test**

- expo

**Issue**

- N/A