### PR TITLE
[expo] implement push notification handler

### DIFF
--- a/expo/features/app/user/internals/UserRoot.tsx
+++ b/expo/features/app/user/internals/UserRoot.tsx
@@ -1,12 +1,17 @@
 import { useCurrentUser, useUserConfig } from '@hpapp/features/app/settings';
 import { Initializer, Loading } from '@hpapp/features/common';
 import { Screen, ScreenParams, createStackNavigator } from '@hpapp/features/common/stack';
-import { usePushNotificationToken, usePushNotificationTokenUpdator } from '@hpapp/features/push';
+import {
+  usePushNotificationToken,
+  usePushNotificationTokenUpdator,
+  PushNotificationData,
+  PushNotificationHandler
+} from '@hpapp/features/push';
 import { logScreenView, useSetUserId } from '@hpapp/system/firebase';
 import * as logging from '@hpapp/system/logging';
 import { init as initURICache } from '@hpapp/system/uricache';
 import { useNavigationContainerRef } from '@react-navigation/native';
-import { useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
 
 import UserError from './UserError';
 import UserServiceProvider from './UserServiceProvider';
@@ -19,11 +24,16 @@ const Stack = createStackNavigator({
 const initializers = [initURICache];
 const Screens: Screen<ScreenParams>[] = [];
 
+// TODO: genscreen should create this param types as well.
+type PushNotificationParams = {
+  '/feed/item/': { feedId: string };
+};
+
 export type UserRootProps = { screens?: Screen<ScreenParams>[] };
 
 export default function UserRoot({ screens = Screens }: UserRootProps) {
   const userConfig = useUserConfig();
-  const navigation = useNavigationContainerRef<ReactNavigation.RootParamList>();
+  const navigation = useNavigationContainerRef<PushNotificationParams>();
   const token = usePushNotificationToken();
   const [tokenUpdator] = usePushNotificationTokenUpdator();
   useEffect(() => {
@@ -33,22 +43,52 @@ export default function UserRoot({ screens = Screens }: UserRootProps) {
   }, [token.data]);
   const currentUser = useCurrentUser();
   useSetUserId(currentUser?.id ?? null);
+  const onData = useCallback((data: PushNotificationData) => {
+    // TODO: if navigation is not ready, we should wait for it, and navigate after it's ready.
+    const nav = navigation?.current;
+    if (nav === null) {
+      return;
+    }
+    if (!nav.isReady()) {
+      return;
+    }
+
+    // we need a compatibility of payload with v2 implementation
+    // == Ameblo Notification payload example
+    // {
+    //   "params": {
+    //     "id": 94489510263,
+    //     "memberKey": "yukiho_shimoitani",
+    //     "path": "/angerme-new/entry-12876844045.html",
+    //     "post_id": 12889971534
+    //   },
+    //   "path": "/ameblo/post/"
+    // }
+    if (data.body.payload.path === '/ameblo/post/') {
+      nav.navigate('/feed/item/', { feedId: data.body.payload.params.id });
+      return;
+    }
+    // in v3, the server should send path and params so that we don't have to handle details.
+    nav.navigate(data.body.payload.path, data.body.payload.params);
+  }, []);
   return (
     <Initializer initializers={initializers}>
       <UserServiceProvider errorFallback={UserError} loadingFallback={<Loading testID="UserRoot.Loading" />}>
-        <Stack
-          ref={navigation}
-          screens={screens}
-          initialRouteName={userConfig?.completeOnboarding ? '/' : '/onboarding/'}
-          onStateChange={(state) => {
-            logScreenView(state.screen.name);
-            logging.Info('features.app.user.onStateChagne', `to ${state.screen.name}`, {
-              name: state.screen.name,
-              path: state.screen.path,
-              params: state.params
-            });
-          }}
-        />
+        <PushNotificationHandler onData={onData}>
+          <Stack
+            ref={navigation}
+            screens={screens}
+            initialRouteName={userConfig?.completeOnboarding ? '/' : '/onboarding/'}
+            onStateChange={(state) => {
+              logScreenView(state.screen.name);
+              logging.Info('features.app.user.onStateChagne', `to ${state.screen.name}`, {
+                name: state.screen.name,
+                path: state.screen.path,
+                params: state.params
+              });
+            }}
+          />
+        </PushNotificationHandler>
       </UserServiceProvider>
     </Initializer>
   );

--- a/expo/features/devtool/DevtoolScreen.tsx
+++ b/expo/features/devtool/DevtoolScreen.tsx
@@ -4,6 +4,7 @@ import { useThemeColor } from '@hpapp/features/app/theme';
 import { AuthGateByRole } from '@hpapp/features/auth';
 import { Text } from '@hpapp/features/common';
 import { defineScreen } from '@hpapp/features/common/stack';
+import { usePushNotificationToken } from '@hpapp/features/push';
 import { getAppCheckToken } from '@hpapp/system/firebase';
 import { t } from '@hpapp/system/i18n';
 import { Divider, ListItem } from '@rneui/themed';
@@ -19,6 +20,8 @@ export default defineScreen('/devtool/', function DevtoolScreen() {
   const appConfig = useAppConfig();
   const userConfig = useUserConfig();
   const [appCheckToken, setAppCheckToken] = useState<string | null>(null);
+  const pushToken = usePushNotificationToken();
+
   useEffect(() => {
     (async () => {
       setAppCheckToken((await getAppCheckToken()).token);
@@ -49,6 +52,15 @@ export default defineScreen('/devtool/', function DevtoolScreen() {
         displayValue={(appCheckToken ?? '').substring(0, 20) + '****'}
       />
       <Divider />
+      <DevtoolListItem
+        name="Push Token"
+        value={pushToken.error !== undefined ? pushToken.error.toString() : (pushToken.data ?? '')}
+        displayValue={
+          pushToken.error !== undefined ? pushToken.error.toString() : (pushToken.data ?? '').substring(0, 20) + '****'
+        }
+      />
+      <Divider />
+
       <ListItemClearCache />
       <Divider />
       <DevtoolUserConfigForm />

--- a/expo/features/feed/FeedItemScreen.tsx
+++ b/expo/features/feed/FeedItemScreen.tsx
@@ -9,7 +9,7 @@ export type FeedItemScreenProps = {
   feedId: string;
 };
 
-export default defineScreen('/feed/', function FeedItemScreen(props: FeedItemScreenProps) {
+export default defineScreen('/feed/item/', function FeedItemScreen(props: FeedItemScreenProps) {
   return (
     <View style={styles.container}>
       <Suspense fallback={<Loading />}>

--- a/expo/features/push/index.tsx
+++ b/expo/features/push/index.tsx
@@ -1,4 +1,4 @@
+import PushNotificationHandler, { PushNotificationData } from './internals/PushNotificationHandler';
 import usePushNotificationToken from './internals/usePushNotificationToken';
 import usePushNotificationTokenUpdator from './internals/usePushNotificationTokenUpdator';
-
-export { usePushNotificationToken, usePushNotificationTokenUpdator };
+export { usePushNotificationToken, usePushNotificationTokenUpdator, PushNotificationHandler, PushNotificationData };

--- a/expo/features/push/internals/PushNotificationHandler.tsx
+++ b/expo/features/push/internals/PushNotificationHandler.tsx
@@ -1,0 +1,50 @@
+import { logEvent } from '@hpapp/system/firebase';
+import * as Notifications from 'expo-notifications';
+import React, { useEffect, useRef } from 'react';
+
+type Subscription = ReturnType<typeof Notifications.addNotificationResponseReceivedListener>;
+
+export type PushNotificationData = {
+  id: string;
+  timestamp: Date;
+  body: {
+    type: string;
+    payload: { [key: string]: any };
+  };
+};
+
+export type PushNotificationHandlerProps = {
+  children: React.ReactElement;
+  onData?: (data: PushNotificationData) => void;
+};
+
+export default function PushNotificationHandler({ children, onData }: PushNotificationHandlerProps) {
+  const responseSubscription = useRef<Subscription>();
+  useEffect(() => {
+    (async () => {
+      responseSubscription.current = Notifications.addNotificationResponseReceivedListener((response) => {
+        const body = response.notification.request.content.data as {
+          type: string;
+          payload: string;
+        };
+        logEvent('respond_to_notification', {
+          body
+        });
+        onData?.({
+          id: response.notification.request.identifier,
+          timestamp: new Date(response.notification.date),
+          body: {
+            type: body.type,
+            payload: JSON.parse(body.payload)
+          }
+        });
+      });
+      return () => {
+        if (responseSubscription.current) {
+          Notifications.removeNotificationSubscription(responseSubscription.current);
+        }
+      };
+    })();
+  }, [onData]);
+  return <>{children}</>;
+}

--- a/expo/jest.setup.tsx
+++ b/expo/jest.setup.tsx
@@ -218,4 +218,5 @@ jest.mock('@hpapp/features/app/storybook', () => {
     }
   };
 });
+
 jest.setTimeout(30000);


### PR DESCRIPTION
**Summary**

We somehow missed that impelmentation in v3.0 and added it from v2.0.

This commit also improve test-notify tool to send push notification to the device multiple times. (and only for testing purpose)

**Test**

- go run ./cmd/ --prod ameblo test-notify -t "****" /angerme-new/entry-12876844045.html
- tap the notificaiton
- then it navigates to FeedItem screen with Yuppyon's latest post (https://ameblo.jp/angerme-new/entry-12876844045.html?frm=theme).

**Issue**

- N/A