### PR TITLE
[eas] add eas update prod workflow

### DIFF
--- a/.github/workflows/eas-update-prod.yml
+++ b/.github/workflows/eas-update-prod.yml
@@ -1,0 +1,24 @@
+name: EAS - Update Production
+on:
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    environment:
+      name: eas
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "22"
+          cache: "yarn"
+          cache-dependency-path: "expo/package.json"
+      - uses: expo/expo-github-action@v8
+        with:
+          eas-version: 13.4.2
+          token: ${{ secrets.EXPO_TOKEN }}
+      - run: cd expo && yarn install
+      - run: cd expo && ./scripts/eas.sh build update --channel prod --non-interactive --auto
+        env:
+          HPAPP_CONFIG_NAME: prod

--- a/expo/package.json
+++ b/expo/package.json
@@ -12,12 +12,7 @@
     "test": "yarn jest ./ --silent",
     "lint": "yarn eslint ./",
     "genscreen": "node ./scripts/genscreen.js",
-    "start-dev": "HPAPP_CONFIG_NAME=dev expo start --dev-client --lan",
     "build-dev": "HPAPP_CONFIG_NAME=dev ./scripts/eas.sh build --profile dev --platform ios --non-interactive",
-    "build-beta": "HPAPP_CONFIG_NAME=beta ./scripts/eas.sh build --profile beta --non-interactive",
-    "build-prod": "HPAPP_CONFIG_NAME=prod ./scripts/eas.sh build --profile prod --platform ios",
-    "update-beta": "HPAPP_CONFIG_NAME=beta ./scripts/eas.sh update --channel beta --non-interactive --auto",
-    "update-prod": "HPAPP_CONFIG_NAME=prod ./scripts/eas.sh update --channel prod --non-interactive --auto",
     "storybook-generate": "sb-rn-get-stories"
   },
   "relay": {


### PR DESCRIPTION
**Summary**

we don't want to trigger OTA update from developer console, but want to do it from Github Actions so that we can log all releases.

**Test**

- N/A

**Issue**

- N/A