### PR TITLE
[eas] Add secrets.json.env files for dev, beta, and prod environments

### DIFF
--- a/.github/workflows/eas-ota-update-auto.yml
+++ b/.github/workflows/eas-ota-update-auto.yml
@@ -24,6 +24,9 @@ jobs:
         with:
           eas-version: 13.4.2
           token: ${{ secrets.EXPO_TOKEN }}
+      - run: cd expo && envsubst < config/beta/secrets.json.env > config/beta/secrets.json
+        env:
+          SECRETS_JSON: ${{ secrets.SECRETS_JSON }}
       - run: cd expo && yarn install
       - run: cd expo && ./scripts/eas.sh update --channel beta --non-interactive --auto
         env:

--- a/.github/workflows/eas-ota-update-manual.yml
+++ b/.github/workflows/eas-ota-update-manual.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           eas-version: 13.4.2
           token: ${{ secrets.EXPO_TOKEN }}
+      - run: cd expo && envsubst < config/${{inputs.config}}/secrets.json.env > config/${{inputs.config}}/secrets.json
+        env:
+          SECRETS_JSON: ${{ secrets.SECRETS_JSON }}
       - run: cd expo && yarn install
       - run: cd expo && ./scripts/eas.sh update --channel ${{inputs.config}} --non-interactive --auto
         env:

--- a/expo/app.config.js
+++ b/expo/app.config.js
@@ -27,13 +27,28 @@ module.exports = (_) => {
 
   if (fs.existsSync(iosGoogleServicesFilePath)) {
     config.ios.googleServicesFile = iosGoogleServicesFilePath;
+  } else {
+    if (isEAS) {
+      throw new Error('GoogleService-Info.plist file does not found in ' + iosGoogleServicesFilePath);
+    }
   }
   if (fs.existsSync(androidGoogleServicesFilePath)) {
     config.android.googleServicesFile = androidGoogleServicesFilePath;
+  } else {
+    if (isEAS) {
+      throw new Error('google-services.json file does not found in ' + androidGoogleServicesFilePath);
+    }
   }
   if (fs.existsSync(secretsJsonPath)) {
     const secretsJson = JSON.parse(fs.readFileSync(secretsJsonPath).toString());
     config.extra.hpapp.graphQLEndpoint = secretsJson.extra.hpapp.graphQLEndpoint;
+  } else {
+    throw new Error(
+      [
+        'secrets.json file does not found in ' + secretsJsonPath,
+        'see https://github.com/yssk22/hpapp/blob/main/docs/expo/build.md#secretsjson section for the format'
+      ].join('\n')
+    );
   }
 
   // finally load the environment specific app.config.js

--- a/expo/config/beta/secrets.json.env
+++ b/expo/config/beta/secrets.json.env
@@ -1,0 +1,1 @@
+$SECRETS_JSON

--- a/expo/config/dev/secrets.json.env
+++ b/expo/config/dev/secrets.json.env
@@ -1,0 +1,1 @@
+$SECRETS_JSON

--- a/expo/config/prod/secrets.json.env
+++ b/expo/config/prod/secrets.json.env
@@ -1,0 +1,1 @@
+$SECRETS_JSON


### PR DESCRIPTION
**Summary**

secrets.json is a file to specify `extra.hpapp` in app.config.js and it can be updated via EAS update.

This means, we need that file when we execute EAS update.

Note that this file is generated on EAS server when we execute EAS build and that explains #170 behavior about why network failure occurrs by OTA updates from Github Action.

With this commit, actions that use eas update have secrets.json generation action from `SECRETS_JSON` environment variable configured in Github Environment.

**Test**

- yarn update-beta

**Issue**

- N/A