### PR TITLE
[expo] improve GraphQL experiences.

### DIFF
--- a/expo/assets/translations.json
+++ b/expo/assets/translations.json
@@ -116,8 +116,11 @@
   "Settings": {
     "ja": "設定"
   },
-  "Sort": {
-    "ja": "ソート"
+  "Sort History": {
+    "ja": "ソート履歴"
+  },
+  "Sort Result": {
+    "ja": "ソート結果"
   },
   "By Sort": {
     "ja": "ソート順"

--- a/expo/features/app/internals/AppGlobalErrorFallback.tsx
+++ b/expo/features/app/internals/AppGlobalErrorFallback.tsx
@@ -11,16 +11,17 @@ import { useSafeAreaInsets } from 'react-native-safe-area-context';
 export default function AppGlobalErrorFallback({ error, errorInfo }: { error: Error; errorInfo: ErrorInfo }) {
   const [color] = useThemeColor('error');
   const insets = useSafeAreaInsets();
+  const hintText = getHintText(error);
   return (
     <ScrollView>
       <View style={[styles.container, { marginTop: insets.top, marginBottom: insets.bottom }]}>
         <Text style={styles.title}>{t('Unexpected error occurred.')}</Text>
         <Text style={[styles.message, { color }]}>{error.message}</Text>
-        <Text style={styles.stack}>{errorInfo.componentStack}</Text>
         <Text style={styles.notice}>
-          {t('Please confirm your network connection and restart the app.')}
+          {hintText}
           {t('Please try to reinstall the app if you continue to see this error.')}
         </Text>
+        <Text style={styles.stack}>{errorInfo.componentStack}</Text>
         <Button
           containerStyle={styles.button}
           onPress={() => {
@@ -55,6 +56,8 @@ const styles = StyleSheet.create({
   },
   notice: {
     fontSize: FontSize.Medium,
+    marginTop: Spacing.Medium,
+    marginBottom: Spacing.Medium,
     marginLeft: Spacing.XLarge,
     marginRight: Spacing.XLarge
   },
@@ -63,3 +66,13 @@ const styles = StyleSheet.create({
     width: '50%'
   }
 });
+
+function getHintText(err: Error): string | undefined {
+  if (err.message.includes('Unexpected HTTP status error')) {
+    return t('Please confirm your network connection and restart the app.');
+  }
+  if (err.message === 'timeout') {
+    return t('Please confirm your network connection and restart the app.');
+  }
+  return err.message;
+}

--- a/expo/features/elineupmall/internal/ElineupMallLimitedTimeItemList.tsx
+++ b/expo/features/elineupmall/internal/ElineupMallLimitedTimeItemList.tsx
@@ -1,6 +1,7 @@
 import { ListItemLoadMore } from '@hpapp/features/common/list';
-import { FlatList } from 'react-native';
-import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
+import { useLazyReloadableQuery } from '@hpapp/system/graphql/hooks';
+import { FlatList, RefreshControl } from 'react-native';
+import { graphql, usePaginationFragment } from 'react-relay';
 
 import { ElineupMallLimitedTimeItemListItem } from './ElineupMallLimitedTimeItemListItem';
 import { ElineupMallLimitedTimeItemListQuery } from './__generated__/ElineupMallLimitedTimeItemListQuery.graphql';
@@ -36,18 +37,22 @@ export type ElineupMallLimitedTimeItemListProps = {
 };
 
 export default function ElineupMallLimitedTimeItemList({ memberIds }: ElineupMallLimitedTimeItemListProps) {
-  const data = useLazyLoadQuery<ElineupMallLimitedTimeItemListQuery>(ElineupMallLimitedTimeItemListQueryGraphQL, {
-    first: numPerFetch,
-    params: {
-      memberIDs: memberIds
+  const { data, isReloading, reload } = useLazyReloadableQuery<ElineupMallLimitedTimeItemListQuery>(
+    ElineupMallLimitedTimeItemListQueryGraphQL,
+    {
+      first: numPerFetch,
+      params: {
+        memberIDs: memberIds
+      }
     }
-  });
+  );
   const histories = usePaginationFragment<
     ElineupMallLimitedTimeItemListQuery,
     ElineupMallLimitedTimeItemListQuery_helloproject_query_elineupmall_items$key
   >(ElineupMallLimitedTimeItemListQueryFragmentGraphQL, data.helloproject);
   return (
     <FlatList
+      refreshControl={<RefreshControl refreshing={isReloading} onRefresh={reload} />}
       keyExtractor={(item) => item!.node!.id}
       data={histories.data.elineupMallItems!.edges}
       renderItem={({ item, index }) => {

--- a/expo/features/home/internals/menu/HomeTabMenu.tsx
+++ b/expo/features/home/internals/menu/HomeTabMenu.tsx
@@ -17,7 +17,7 @@ import HomeTabSettingsVersionSignature from './HomeTabMenuVersionSignature';
 export default function HomeTabMenu() {
   return (
     <ScrollView>
-      <NavigationListItem screen={HPSortScreen}>{t('Sort')}</NavigationListItem>
+      <NavigationListItem screen={HPSortScreen}>{t('Sort History')}</NavigationListItem>
       <Divider />
       <NavigationListItem screen={UPFCHistoryScreen}>{t('Event History')}</NavigationListItem>
       <Divider />

--- a/expo/features/home/internals/menu/__snapshots__/MenuTab.test.tsx.snap
+++ b/expo/features/home/internals/menu/__snapshots__/MenuTab.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`SettingsTab render 1`] = `
                           ]
                         }
                       >
-                        ソート
+                        ソート履歴
                       </Text>
                     </View>
                     <View

--- a/expo/features/hpsort/HPSortResultScreen.tsx
+++ b/expo/features/hpsort/HPSortResultScreen.tsx
@@ -15,7 +15,7 @@ type HPSortResultScreenProps = {
 export default defineScreen(
   '/hpsort/result/',
   function HPSortResultScreen({ current, previous }: HPSortResultScreenProps) {
-    useScreenTitle(t('Sort'));
+    useScreenTitle(t('Sort Result'));
     const list = useMemo(() => {
       return compareMemberRankDiff(current, previous);
     }, [current, previous]);

--- a/expo/features/hpsort/HPSortScreen.tsx
+++ b/expo/features/hpsort/HPSortScreen.tsx
@@ -4,6 +4,6 @@ import { t } from '@hpapp/system/i18n';
 import HPSortHistoryList from './internals/HPSortHistoryList';
 
 export default defineScreen('/hpsort/', function HPSortSceen() {
-  useScreenTitle(t('Sort'));
+  useScreenTitle(t('Sort History'));
   return <HPSortHistoryList />;
 });

--- a/expo/features/hpsort/internals/HPSortHistoryList.tsx
+++ b/expo/features/hpsort/internals/HPSortHistoryList.tsx
@@ -1,7 +1,8 @@
 import { ListItemLoadMore } from '@hpapp/features/common/list';
 import { sortRecordsToMemberRank } from '@hpapp/features/hpsort/helper';
-import { FlatList } from 'react-native';
-import { graphql, useLazyLoadQuery, usePaginationFragment } from 'react-relay';
+import { useLazyReloadableQuery } from '@hpapp/system/graphql/hooks';
+import { FlatList, RefreshControl } from 'react-native';
+import { graphql, usePaginationFragment } from 'react-relay';
 
 import HPSortHistoryListItem from './HPSortHistoryListItem';
 import { HPSortHistoryListQuery } from './__generated__/HPSortHistoryListQuery.graphql';
@@ -41,7 +42,7 @@ const HPSortHistoryListQueryFragmentGraphQL = graphql`
 const numPerFetch = 10;
 
 export default function HPSortHistoryList() {
-  const data = useLazyLoadQuery<HPSortHistoryListQuery>(HPSortHistoryListQueryGraphQL, {
+  const { data, isReloading, reload } = useLazyReloadableQuery<HPSortHistoryListQuery>(HPSortHistoryListQueryGraphQL, {
     first: numPerFetch
   });
   const histories = usePaginationFragment<HPSortHistoryListQuery, HPSortHistoryListQuery_me_query_sortHistories$key>(
@@ -50,6 +51,7 @@ export default function HPSortHistoryList() {
   );
   return (
     <FlatList
+      refreshControl={<RefreshControl refreshing={isReloading} onRefresh={reload} />}
       keyExtractor={(item) => item!.node!.id}
       data={histories.data.sortHistories!.edges}
       renderItem={({ item, index }) => {

--- a/expo/system/graphql/hooks.tsx
+++ b/expo/system/graphql/hooks.tsx
@@ -1,0 +1,44 @@
+import { useCallback, useState } from 'react';
+import {
+  FetchPolicy,
+  fetchQuery,
+  GraphQLTaggedNode,
+  useLazyLoadQuery,
+  useRelayEnvironment,
+  Variables
+} from 'react-relay';
+import { OperationType } from 'relay-runtime';
+
+type QueryOptinos = {
+  fetchKey?: number | undefined;
+  fetchPolicy?: FetchPolicy | undefined;
+};
+
+export function useLazyReloadableQuery<TQuery extends OperationType>(
+  taggedNode: GraphQLTaggedNode,
+  variables: Variables
+) {
+  const [isReloading, setIsReloading] = useState(false);
+  const [refreshedQueryOptions, setRefreshedQueryOptions] = useState<QueryOptinos>({});
+  const env = useRelayEnvironment();
+  const reload = useCallback(() => {
+    if (isReloading) {
+      return;
+    }
+    setIsReloading(true);
+    fetchQuery(env, taggedNode, variables).subscribe({
+      complete: () => {
+        setIsReloading(false);
+        setRefreshedQueryOptions((prev) => ({
+          fetchKey: (prev?.fetchKey ?? 0) + 1,
+          fetchPolicy: 'network-only'
+        }));
+      },
+      error: () => {
+        setIsReloading(false);
+      }
+    });
+  }, [variables]);
+  const data = useLazyLoadQuery<TQuery>(taggedNode, variables, refreshedQueryOptions);
+  return { data, isReloading, reload };
+}


### PR DESCRIPTION
**Summary**

- introduced `useLazyReloadableQuery` hook to make it easy to implement `<RefreshControl>` with `useLazyLoadQuery()`.
- `HPSortHistoryList` and `ElineupMallLimitedTimeItemList` now use `useLazyReloadableQuery` to implement pull-to-refresh feature.
- directly throw GraphQL exception for AppGlobalErrorFallback to handle.

**Test**

- expo

**Issue**

- fix #141