### PR TITLE
[expo] prefill credentials when opening elineupmall.

### DIFF
--- a/expo/assets/translations.json
+++ b/expo/assets/translations.json
@@ -198,10 +198,10 @@
     "ja": "Tシャツ"
   },
   "Elineup Mall Settings": {
-    "ja": "Elineup!Mallの設定"
+    "ja": "e-Lineup!Mallの設定"
   },
   "Fetch Elnieup Mall Purchase History": {
-    "ja": "Elineup!Mallの購入履歴を取得"
+    "ja": "e-Lineup!Mallの購入履歴を取得"
   },
   "Already In Cart": {
     "ja": "すでにカートに入っています"
@@ -216,7 +216,7 @@
     "ja": "カートから削除"
   },
   "FC credentials will be used to fetch your purchase history from elineupmall.": {
-    "ja": "ファンクラブの認証情報を使用して、Elineup!Mallから購入履歴を取得します。"
+    "ja": "ファンクラブの認証情報を使用して、e-Lineup!Mallから購入履歴を取得します。"
   },
   "Following settings per a member per a category": {
     "ja": "メンバーごとのカテゴリごとのフォロー設定"

--- a/expo/features/elineupmall/ElineupMallWebViewScreen.tsx
+++ b/expo/features/elineupmall/ElineupMallWebViewScreen.tsx
@@ -1,13 +1,12 @@
+import { useUPFCConfig } from '@hpapp/features/app/settings';
+import { useThemeColor } from '@hpapp/features/app/theme';
+import { Spacing } from '@hpapp/features/common/constants';
 import { defineScreen, useScreenTitle } from '@hpapp/features/common/stack';
-import { useRef } from 'react';
+import { Button, Icon } from '@rneui/themed';
+import { useCallback, useRef } from 'react';
 import { View, StyleSheet } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { WebView } from 'react-native-webview';
-
-const styles = StyleSheet.create({
-  webviewConainer: {
-    flex: 1
-  }
-});
 
 export type UPFCWebViewScreenProps = {
   login?: boolean;
@@ -18,13 +17,63 @@ export default defineScreen(
   '/elineupmall/wv/',
   function ElineupMallWebView({ login = false, uri }: UPFCWebViewScreenProps) {
     useScreenTitle('Elineup Mall');
+    const insets = useSafeAreaInsets();
+    const [color, contrastColor] = useThemeColor('secondary');
     const webview = useRef<WebView>(null);
+    const config = useUPFCConfig();
+    const username = config?.hpUsername ?? '';
+    const password = config?.hpPassword ?? '';
+    const onLoadEnd = useCallback(() => {
+      webview?.current?.injectJavaScript(`(function(){
+        document.querySelector('#account_info_3 .ty-account-info__buttons a.ty-btn.ty-btn__secondary').click()
+        document.querySelectorAll('input[name="user_login"]').forEach((elem)=> {elem.value=${JSON.stringify(username)}});
+        document.querySelectorAll('input[name="password"]').forEach((elem)=> {elem.value=${JSON.stringify(password)}});
+      })();
+`);
+    }, [uri, username, password, webview]);
+
     return (
       <>
         <View style={styles.webviewConainer}>
-          <WebView ref={webview} source={{ uri }} />
+          <WebView ref={webview} source={{ uri }} onLoadEnd={onLoadEnd} />
+          <View style={[styles.webviewFooter, { paddingBottom: insets.bottom, backgroundColor: contrastColor }]}>
+            <Button
+              type="clear"
+              containerStyle={styles.webviewFooterButton}
+              icon={<Icon name="caretleft" type="antdesign" color={color} />}
+              onPress={() => webview?.current?.goBack()}
+            />
+            <Button
+              type="clear"
+              containerStyle={styles.webviewFooterButton}
+              icon={<Icon name="caretright" type="antdesign" color={color} />}
+              onPress={() => webview?.current?.goForward()}
+            />
+            <Button
+              type="clear"
+              containerStyle={styles.webviewFooterButton}
+              icon={<Icon name="reload1" type="antdesign" color={color} />}
+              onPress={() => webview?.current?.reload()}
+            />
+          </View>
         </View>
       </>
     );
   }
 );
+
+const styles = StyleSheet.create({
+  webviewConainer: {
+    flex: 1
+  },
+  webviewMain: {
+    flex: 1
+  },
+  webviewFooter: {
+    flexDirection: 'row',
+    paddingTop: Spacing.XSmall
+  },
+  webviewFooterButton: {
+    flexGrow: 1
+  }
+});

--- a/expo/features/elineupmall/internal/ElineupMallOpenCartButton.tsx
+++ b/expo/features/elineupmall/internal/ElineupMallOpenCartButton.tsx
@@ -1,13 +1,39 @@
+import { useThemeColor } from '@hpapp/features/app/theme';
 import { Spacing } from '@hpapp/features/common/constants';
-import { Button } from '@rneui/themed';
+import { useNavigation } from '@hpapp/features/common/stack';
+import ElineupMallWebViewScreen from '@hpapp/features/elineupmall/ElineupMallWebViewScreen';
+import { Button, Icon } from '@rneui/themed';
+import { useCallback } from 'react';
 import { View, StyleSheet } from 'react-native';
 
+import { useElineupMall } from './ElineupMallProvider';
 import ElineupMallStatusIcon from './ElineupMallStatusIcon';
 
 export default function ElineupMallOpenCartButton() {
+  const elineupmall = useElineupMall();
+  const navigation = useNavigation();
+  const [secondary] = useThemeColor('secondary');
+  const numberOfItems = elineupmall.cart?.size ?? 0;
+  const text = `(${numberOfItems})`;
+  const onPress = useCallback(() => {
+    switch (elineupmall.status) {
+      case 'error_not_opted_in':
+      case 'error_upfc_is_empty':
+      case 'error_unknown':
+      case 'error_authenticate':
+        navigation.push(ElineupMallWebViewScreen, {
+          uri: 'https://www.elineupmall.com/'
+        });
+        break;
+      case 'ready':
+        navigation.push(ElineupMallWebViewScreen, {
+          uri: numberOfItems > 0 ? 'https://www.elineupmall.com/cart/' : 'https://www.elineupmall.com/',
+          login: true
+        });
+    }
+  }, [numberOfItems, elineupmall.status]);
   return (
     <Button
-      title="Elineup!Mall"
       type="outline"
       size="sm"
       color="secondary"
@@ -17,8 +43,12 @@ export default function ElineupMallOpenCartButton() {
           <ElineupMallStatusIcon />
         </View>
       }
-      onPress={() => {}}
-    />
+      onPress={onPress}
+    >
+      e-Lineup!Mall
+      <Icon name="shopping-cart" type="fontawesome" color={secondary} />
+      {numberOfItems > 0 && text}
+    </Button>
   );
 }
 

--- a/expo/features/home/internals/menu/__snapshots__/MenuTab.test.tsx.snap
+++ b/expo/features/home/internals/menu/__snapshots__/MenuTab.test.tsx.snap
@@ -903,7 +903,7 @@ exports[`SettingsTab render 1`] = `
                           ]
                         }
                       >
-                        Elineup!Mallの設定
+                        e-Lineup!Mallの設定
                       </Text>
                     </View>
                     <View


### PR DESCRIPTION
**Summary**

we want to shortcut the process to start checkout.

- when there is an item in the cart, webview will open /cart/ page and open the popup to login with prefilled credentials.
- users can just tap the login and start checkout.

**Test**

- expo

**Issue**

- #118