### PR TITLE
[expo] clean up cookie everytime switching between fetch and WebView.

### DIFF
--- a/expo/features/elineupmall/ElineupMallWebViewScreen.tsx
+++ b/expo/features/elineupmall/ElineupMallWebViewScreen.tsx
@@ -31,7 +31,6 @@ export default defineScreen(
       })();
 `);
     }, [uri, username, password, webview]);
-
     return (
       <>
         <View style={styles.webviewConainer}>

--- a/expo/features/elineupmall/internal/ElineupMallLimitedTimeItemList.tsx
+++ b/expo/features/elineupmall/internal/ElineupMallLimitedTimeItemList.tsx
@@ -4,6 +4,7 @@ import { FlatList, RefreshControl } from 'react-native';
 import { graphql, usePaginationFragment } from 'react-relay';
 
 import { ElineupMallLimitedTimeItemListItem } from './ElineupMallLimitedTimeItemListItem';
+import { useElineupMall } from './ElineupMallProvider';
 import {
   ElineupMallLimitedTimeItemListQuery,
   HPElineupMallItemCategory
@@ -50,9 +51,9 @@ export type ElineupMallLimitedTimeItemListProps = {
 export default function ElineupMallLimitedTimeItemList({
   memberCategories,
   memberIds,
-  categories,
-  historyMap
+  categories
 }: ElineupMallLimitedTimeItemListProps) {
+  const elineupmall = useElineupMall();
   const { data, isReloading, reload } = useLazyReloadableQuery<ElineupMallLimitedTimeItemListQuery>(
     ElineupMallLimitedTimeItemListQueryGraphQL,
     {
@@ -70,7 +71,15 @@ export default function ElineupMallLimitedTimeItemList({
   >(ElineupMallLimitedTimeItemListQueryFragmentGraphQL, data.helloproject);
   return (
     <FlatList
-      refreshControl={<RefreshControl refreshing={isReloading} onRefresh={reload} />}
+      refreshControl={
+        <RefreshControl
+          refreshing={isReloading}
+          onRefresh={() => {
+            elineupmall.reload();
+            reload();
+          }}
+        />
+      }
       keyExtractor={(item) => item!.node!.id}
       data={histories.data.elineupMallItems!.edges}
       renderItem={({ item, index }) => {

--- a/expo/features/elineupmall/internal/ElineupMallOpenCartButton.tsx
+++ b/expo/features/elineupmall/internal/ElineupMallOpenCartButton.tsx
@@ -2,6 +2,7 @@ import { useThemeColor } from '@hpapp/features/app/theme';
 import { Spacing } from '@hpapp/features/common/constants';
 import { useNavigation } from '@hpapp/features/common/stack';
 import ElineupMallWebViewScreen from '@hpapp/features/elineupmall/ElineupMallWebViewScreen';
+import CookieManager from '@react-native-cookies/cookies';
 import { Button, Icon } from '@rneui/themed';
 import { useCallback } from 'react';
 import { View, StyleSheet } from 'react-native';
@@ -16,6 +17,9 @@ export default function ElineupMallOpenCartButton() {
   const numberOfItems = elineupmall.cart?.size ?? 0;
   const text = `(${numberOfItems})`;
   const onPress = useCallback(() => {
+    // clean the cookie.
+    // TODO: clear cookies only for elineupmall.com
+    CookieManager.clearAll();
     switch (elineupmall.status) {
       case 'error_not_opted_in':
       case 'error_upfc_is_empty':

--- a/expo/features/elineupmall/internal/ElineupMallStatusIcon.tsx
+++ b/expo/features/elineupmall/internal/ElineupMallStatusIcon.tsx
@@ -10,6 +10,7 @@ export default function ElineupMallStatusIcon() {
   const [successColor] = useThemeColor('success');
   const [errorColor] = useThemeColor('error');
   const [disabledColor] = useThemeColor('disabled');
+
   switch (elineupmall.status) {
     case 'ready':
       return <Icon color={successColor} name="check-circle" type="fontawesome" size={IconSize.Small} />;
@@ -20,7 +21,7 @@ export default function ElineupMallStatusIcon() {
     case 'error_unknown':
       return <Icon color={errorColor} name="error" type="material-icons" size={IconSize.Small} />;
     case 'error_authenticate':
-      return <Icon color={errorColor} name="error" type="material-icons" size={IconSize.Small} />;
+      return <Icon color={errorColor} name="account-alert" type="material-community" size={IconSize.Small} />;
     default:
       return <ActivityIndicator color={successColor} size="small" />;
   }

--- a/expo/features/elineupmall/scraper/index.ts
+++ b/expo/features/elineupmall/scraper/index.ts
@@ -1,5 +1,11 @@
 import ElineupMallHttpFetcher from './internals/ElineupMallHttpFetcher';
-import ElineupMallSiteScraper from './internals/ElineupMallSiteScraper';
+import ElineupMallSiteScraper, { ElineupMallSiteAuthError } from './internals/ElineupMallSiteScraper';
 import { ElineupMallOrder, ElineupMallOrderDetail } from './internals/types';
 
-export { ElineupMallOrder, ElineupMallOrderDetail, ElineupMallSiteScraper, ElineupMallHttpFetcher };
+export {
+  ElineupMallOrder,
+  ElineupMallOrderDetail,
+  ElineupMallSiteScraper,
+  ElineupMallHttpFetcher,
+  ElineupMallSiteAuthError
+};

--- a/expo/features/elineupmall/scraper/internals/ElineupMallFileFetcher.ts
+++ b/expo/features/elineupmall/scraper/internals/ElineupMallFileFetcher.ts
@@ -7,6 +7,7 @@ import { ElineupMallFetcher } from './types';
  */
 export default class ElineupMallFileFetcher implements ElineupMallFetcher {
   private paths: {
+    topHTMLPath: string;
     authResultHTMLPath: string;
     orderListHTMLPath: string;
     orderDetailHTMLPath: string;
@@ -14,6 +15,7 @@ export default class ElineupMallFileFetcher implements ElineupMallFetcher {
   };
 
   constructor(paths: {
+    topHTMLPath: string;
     authResultHTMLPath: string;
     orderListHTMLPath: string;
     orderDetailHTMLPath: string;
@@ -24,6 +26,10 @@ export default class ElineupMallFileFetcher implements ElineupMallFetcher {
 
   async postCredential(username: string, password: string): Promise<string> {
     return await this.readFile(this.paths.authResultHTMLPath);
+  }
+
+  async fetchTop(): Promise<string> {
+    return await this.readFile(this.paths.topHTMLPath);
   }
 
   async fetchOrderListHtml(page: number): Promise<string> {

--- a/expo/features/elineupmall/scraper/internals/ElineupMallHttpFetcher.ts
+++ b/expo/features/elineupmall/scraper/internals/ElineupMallHttpFetcher.ts
@@ -12,8 +12,6 @@ export default class ElineupMallHttpFetcher implements ElineupMallFetcher {
    */
   async postCredential(username: string, password: string): Promise<string> {
     const url = `https://www.elineupmall.com/`;
-
-    await this.fetch(url); // dummy request to generate session
     const params = new URLSearchParams();
     params.append('return_url', 'index.php');
     params.append('redirect_url', 'index.php');
@@ -30,6 +28,10 @@ export default class ElineupMallHttpFetcher implements ElineupMallFetcher {
       credentials: 'include'
     });
     return await resp.text();
+  }
+
+  async fetchTop(): Promise<string> {
+    return await this.fetch(`https://www.elineupmall.com/`);
   }
 
   async fetchOrderListHtml(page: number): Promise<string> {

--- a/expo/features/elineupmall/scraper/internals/ElineupMallSiteScraper.test.ts
+++ b/expo/features/elineupmall/scraper/internals/ElineupMallSiteScraper.test.ts
@@ -4,99 +4,94 @@ import ElineupMallFileFetcher from './ElineupMallFileFetcher';
 import ElineupMallSiteScraper from './ElineupMallSiteScraper';
 
 describe('ElineupMallSiteScraper', () => {
-  describe('authenticate', () => {
-    it('success', async () => {
-      const scraper = new ElineupMallSiteScraper(
-        new ElineupMallFileFetcher({
-          authResultHTMLPath: path.join(__dirname, './testdata/auth_success.html'),
-          orderListHTMLPath: '',
-          orderDetailHTMLPath: '',
-          cartHTMLPath: ''
-        })
-      );
-      const ok = await scraper.authenticate('mizuki', 'fukumura');
-      expect(ok).toBe(true);
-    });
-
-    it('error', async () => {
-      const scraper = new ElineupMallSiteScraper(
-        new ElineupMallFileFetcher({
-          authResultHTMLPath: path.join(__dirname, './testdata/auth_error.html'),
-          orderListHTMLPath: '',
-          orderDetailHTMLPath: '',
-          cartHTMLPath: ''
-        })
-      );
-      const ok = await scraper.authenticate('mizuki', 'fukumura');
-      expect(ok).toBe(false);
-    });
-  });
-
-  it('order_list', async () => {
+  it('auth error', async () => {
     const scraper = new ElineupMallSiteScraper(
+      'risa',
+      'password',
       new ElineupMallFileFetcher({
-        authResultHTMLPath: '',
+        topHTMLPath: path.join(__dirname, './testdata/auth_error.html'),
+        authResultHTMLPath: path.join(__dirname, './testdata/auth_error.html'),
         orderListHTMLPath: path.join(__dirname, './testdata/order_list.html'),
         orderDetailHTMLPath: path.join(__dirname, './testdata/order_detail.html'),
         cartHTMLPath: ''
       })
     );
-    const list = await scraper.getOrderList(new Date('2024-08-04T00:00:00+09:00'));
-    expect(list.length).toBe(3);
-    expect(list[0].id).toBe('1430811');
-    expect(list[0].status).toBe('payment_confirmed');
-    expect(list[0].orderedAt.toISOString()).toBe('2024-12-23T07:33:00.000Z');
-    expect(list[1].id).toBe('1397584');
-    expect(list[1].status).toBe('payment_confirmed');
-    expect(list[1].orderedAt.toISOString()).toBe('2024-10-20T08:58:00.000Z');
-    expect(list[2].id).toBe('1375993');
-    expect(list[2].status).toBe('shipped');
-    expect(list[2].orderedAt.toISOString()).toBe('2024-08-30T09:22:00.000Z');
+    const [list, err] = await scraper.getOrderList(new Date('2024-08-04T00:00:00+09:00'));
+    expect(list).toBe(undefined);
+    expect(err).toBeInstanceOf(Error);
+  });
 
-    expect(list[0].details.length).toBe(1);
-    expect(list[0].details[0].name).toBe(
+  it('getOrderList', async () => {
+    const scraper = new ElineupMallSiteScraper(
+      'risa',
+      'password',
+      new ElineupMallFileFetcher({
+        topHTMLPath: path.join(__dirname, './testdata/auth_error.html'),
+        authResultHTMLPath: path.join(__dirname, './testdata/auth_success.html'),
+        orderListHTMLPath: path.join(__dirname, './testdata/order_list.html'),
+        orderDetailHTMLPath: path.join(__dirname, './testdata/order_detail.html'),
+        cartHTMLPath: ''
+      })
+    );
+    const [list] = await scraper.getOrderList(new Date('2024-08-04T00:00:00+09:00'));
+    expect(list!.length).toBe(3);
+    expect(list![0].id).toBe('1430811');
+    expect(list![0].status).toBe('payment_confirmed');
+    expect(list![0].orderedAt.toISOString()).toBe('2024-12-23T07:33:00.000Z');
+    expect(list![1].id).toBe('1397584');
+    expect(list![1].status).toBe('payment_confirmed');
+    expect(list![1].orderedAt.toISOString()).toBe('2024-10-20T08:58:00.000Z');
+    expect(list![2].id).toBe('1375993');
+    expect(list![2].status).toBe('shipped');
+    expect(list![2].orderedAt.toISOString()).toBe('2024-08-30T09:22:00.000Z');
+
+    expect(list![0].details.length).toBe(1);
+    expect(list![0].details[0].name).toBe(
       '2024年12月通信販売 DVD「Juice=Juice 工藤由愛バースデーイベント2024 /Juice=Juice 有澤一華・入江里咲・江端妃咲FCイベント2024」'
     );
-    expect(list[0].details[0].name).toBe(
+    expect(list![0].details[0].name).toBe(
       '2024年12月通信販売 DVD「Juice=Juice 工藤由愛バースデーイベント2024 /Juice=Juice 有澤一華・入江里咲・江端妃咲FCイベント2024」'
     );
-    expect(list[0].details[0].unitPrice).toBe(8250);
-    expect(list[0].details[0].num).toBe(1);
-    expect(list[0].details[0].totalPrice).toBe(8250);
-    expect(list[0].details[0].code).toBe('HP2412_H-03');
-    expect(list[0].details[0].link).toBe(
+    expect(list![0].details[0].unitPrice).toBe(8250);
+    expect(list![0].details[0].num).toBe(1);
+    expect(list![0].details[0].totalPrice).toBe(8250);
+    expect(list![0].details[0].code).toBe('HP2412_H-03');
+    expect(list![0].details[0].link).toBe(
       'https://www.elineupmall.com/c720/c2784/202412-dvdjuicejuice-2024-juicejuice-fc2024-alp84jmu/'
     );
   });
 
-  it('cart', async () => {
+  it('getCart', async () => {
     const scraper = new ElineupMallSiteScraper(
+      'risa',
+      'password',
       new ElineupMallFileFetcher({
-        authResultHTMLPath: '',
+        topHTMLPath: path.join(__dirname, './testdata/auth_error.html'),
+        authResultHTMLPath: path.join(__dirname, './testdata/auth_success.html'),
         orderListHTMLPath: '',
         orderDetailHTMLPath: '',
         cartHTMLPath: path.join(__dirname, './testdata/cart.html')
       })
     );
-    const cart = await scraper.getCart();
-    expect(cart.details.length).toBe(2);
-    expect(cart.details[0].link).toBe('https://www.elineupmall.com/c671/c181/c197/c199/25-t-f6pdtyr4/');
-    expect(cart.details[0].code).toBe('134585');
-    expect(cart.details[0].num).toBe(1);
-    expect(cart.details[0].unitPrice).toBe(4500);
-    expect(cart.details[0].totalPrice).toBe(4500);
-    expect(cart.details[0].deleteLink).toBe(
+    const [cart] = await scraper.getCart();
+    expect(cart!.details.length).toBe(2);
+    expect(cart!.details[0].link).toBe('https://www.elineupmall.com/c671/c181/c197/c199/25-t-f6pdtyr4/');
+    expect(cart!.details[0].code).toBe('134585');
+    expect(cart!.details[0].num).toBe(1);
+    expect(cart!.details[0].unitPrice).toBe(4500);
+    expect(cart!.details[0].totalPrice).toBe(4500);
+    expect(cart!.details[0].deleteLink).toBe(
       'https://www.elineupmall.com/index.php?dispatch=checkout.delete&cart_id=3000325925&redirect_mode=cart'
     );
 
-    expect(cart.details[1].link).toBe(
+    expect(cart!.details[1].link).toBe(
       'https://www.elineupmall.com/c671/c181/c197/c201/juicejuice-shop-2024-hp-color1l-11128-0224-cxwz7rmy/'
     );
-    expect(cart.details[1].code).toBe('403661');
-    expect(cart.details[1].num).toBe(1);
-    expect(cart.details[1].unitPrice).toBe(160);
-    expect(cart.details[1].totalPrice).toBe(160);
-    expect(cart.details[1].deleteLink).toBe(
+    expect(cart!.details[1].code).toBe('403661');
+    expect(cart!.details[1].num).toBe(1);
+    expect(cart!.details[1].unitPrice).toBe(160);
+    expect(cart!.details[1].totalPrice).toBe(160);
+    expect(cart!.details[1].deleteLink).toBe(
       'https://www.elineupmall.com/index.php?dispatch=checkout.delete&cart_id=910172466&redirect_mode=cart'
     );
   });

--- a/expo/features/elineupmall/scraper/internals/ElineupMallSiteScraper.ts
+++ b/expo/features/elineupmall/scraper/internals/ElineupMallSiteScraper.ts
@@ -1,59 +1,80 @@
+import TaskQueue, { TaskQueueResult } from '@hpapp/foundation/TaskQueue';
 import { parse } from 'node-html-parser';
 
-import {
-  ElineupMallFetcher,
-  ElineupMallOrder,
-  ElineupMallOrderDetail,
-  ElineupMallOrderStatus,
-  ElineupMallScraper
-} from './types';
+import { ElineupMallFetcher, ElineupMallOrder, ElineupMallOrderDetail, ElineupMallOrderStatus } from './types';
+
+export class ElineupMallSiteAuthError extends Error {}
+
+let countAuthError = 0;
 
 /**
  * a ElineupMallSiteScraper scrape html for elineupmall.com
  */
-export default class ElineupMallSiteScraper implements ElineupMallScraper {
+export default class ElineupMallSiteScraper extends TaskQueue {
+  private readonly username: string;
+  private readonly password: string;
   private readonly fetcher: ElineupMallFetcher;
 
-  constructor(fetcher: ElineupMallFetcher) {
+  constructor(username: string, password: string, fetcher: ElineupMallFetcher) {
+    super();
+    this.username = username;
+    this.password = password;
     this.fetcher = fetcher;
   }
 
-  public async authenticate(username: string, password: string): Promise<boolean> {
-    const html = await this.fetcher.postCredential(username, password);
-    const root = parse(html);
-    const text = root.querySelector('div.cm-notification-container')?.text;
-    if (text === undefined) {
-      return false;
+  private async authenticate(): Promise<void> {
+    if (countAuthError > 3) {
+      // In this case, IP address may be blocked if the app still tries to authenticate.
+      // to avoid this, the app should stop trying to authenticate and users should authenticate via the normal browser and reboot the app to reset the count.
+      throw new ElineupMallSiteAuthError('3 authentication errors happened with the accuont.');
     }
-    return text.indexOf('ログインに成功') >= 0;
+    let html = await this.fetcher.fetchTop();
+    const root = parse(html);
+    const loggedIn = root.querySelector('div.ty-dropdown-box__title')?.classList.contains('logged');
+    if (!loggedIn) {
+      html = await this.fetcher.postCredential(this.username, this.password);
+      const root = parse(html);
+      const text = root.querySelector('div.cm-notification-container')?.text;
+      if (text === undefined) {
+        countAuthError++;
+        throw new ElineupMallSiteAuthError('failed to authenticate');
+      }
+      if (text.indexOf('ログインに成功') < 0) {
+        countAuthError++;
+        throw new ElineupMallSiteAuthError('failed to authenticate');
+      }
+    }
   }
 
-  public async getOrderList(from: Date): Promise<ElineupMallOrder[]> {
-    const html = await this.fetcher.fetchOrderListHtml(1);
-    const root = parse(html);
-    let orders = root.querySelectorAll('table.ty-orders-search > tr').map((row) => {
-      const id = row.querySelector('td:nth-child(1)')?.text.trim().replace('#', '');
-      const status = toOrderStatus(row.querySelector('td:nth-child(2)')?.text.trim());
-      const orderedAt = new Date(
-        row.querySelector('td:nth-child(4)')?.text.trim().replaceAll('/', '-').replace(', ', 'T') + ':00+09:00'
+  public async getOrderList(from: Date): Promise<TaskQueueResult<ElineupMallOrder[]>> {
+    return this.enqueue(async () => {
+      await this.authenticate();
+      const html = await this.fetcher.fetchOrderListHtml(1);
+      const root = parse(html);
+      let orders = root.querySelectorAll('table.ty-orders-search > tr').map((row) => {
+        const id = row.querySelector('td:nth-child(1)')?.text.trim().replace('#', '');
+        const status = toOrderStatus(row.querySelector('td:nth-child(2)')?.text.trim());
+        const orderedAt = new Date(
+          row.querySelector('td:nth-child(4)')?.text.trim().replaceAll('/', '-').replace(', ', 'T') + ':00+09:00'
+        );
+        return {
+          id: id ?? '',
+          status,
+          orderedAt,
+          details: []
+        } as ElineupMallOrder;
+      });
+      orders = orders.filter((order) => {
+        return order.id !== '' && order.status !== 'unknown' && order.orderedAt.getTime() >= from.getTime();
+      });
+      orders = await Promise.all(
+        orders.map(async (o) => {
+          o.details = await this.fetchOrderDetail(o.id);
+          return o;
+        })
       );
-      return {
-        id: id ?? '',
-        status,
-        orderedAt,
-        details: []
-      } as ElineupMallOrder;
+      return orders.filter((order) => order.details?.length > 0);
     });
-    orders = orders.filter((order) => {
-      return order.id !== '' && order.status !== 'unknown' && order.orderedAt.getTime() >= from.getTime();
-    });
-    orders = await Promise.all(
-      orders.map(async (o) => {
-        o.details = await this.fetchOrderDetail(o.id);
-        return o;
-      })
-    );
-    return orders.filter((order) => order.details?.length > 0);
   }
 
   private async fetchOrderDetail(id: string): Promise<ElineupMallOrderDetail[]> {
@@ -103,88 +124,99 @@ export default class ElineupMallSiteScraper implements ElineupMallScraper {
     });
   }
 
-  public async getCart(): Promise<ElineupMallOrder> {
-    const html = await this.fetcher.fetchCartHtml();
-    const root = parse(html);
-    const details: ElineupMallOrderDetail[] = root.querySelectorAll('table.ty-cart-content > tbody > tr').map((row) => {
-      const description = row.querySelector('td.ty-cart-content__description');
-      const a = description?.querySelector('a.ty-cart-content__product-title') ?? null;
-      const deleteA = description?.querySelector('a.ty-cart-content__product-delete') ?? null;
-      if (a === null || deleteA === null) {
-        return {
-          name: '',
-          num: 0,
-          link: '',
-          code: '',
-          unitPrice: 0,
-          totalPrice: 0
-        };
-      }
-      const name = a.innerHTML.trim();
-      const link = a.getAttribute('href') ?? '';
-      const deleteLink = deleteA.getAttribute('href') ?? '';
-      const code =
-        description?.querySelector('div.ty-cart-content__sku > span')?.text.replaceAll('&nbsp;', '').trim() ?? '';
-      const unitPriceText = row.querySelector('td.ty-cart-content__price > span')?.text.replaceAll(',', '');
-      const unitPrice = parseInt(unitPriceText ?? '0', 10);
-      const qtyInput = row.querySelector('td.ty-cart-content__qty input.ty-value-changer__input');
-      const num = parseInt(qtyInput?.getAttribute('value') ?? '0', 10);
+  public async getCart(): Promise<TaskQueueResult<ElineupMallOrder>> {
+    return this.enqueue(async () => {
+      await this.authenticate();
+      const html = await this.fetcher.fetchCartHtml();
+      const root = parse(html);
+      const details: ElineupMallOrderDetail[] = root
+        .querySelectorAll('table.ty-cart-content > tbody > tr')
+        .map((row) => {
+          const description = row.querySelector('td.ty-cart-content__description');
+          const a = description?.querySelector('a.ty-cart-content__product-title') ?? null;
+          const deleteA = description?.querySelector('a.ty-cart-content__product-delete') ?? null;
+          if (a === null || deleteA === null) {
+            return {
+              name: '',
+              num: 0,
+              link: '',
+              code: '',
+              unitPrice: 0,
+              totalPrice: 0
+            };
+          }
+          const name = a.innerHTML.trim();
+          const link = a.getAttribute('href') ?? '';
+          const deleteLink = deleteA.getAttribute('href') ?? '';
+          const code =
+            description?.querySelector('div.ty-cart-content__sku > span')?.text.replaceAll('&nbsp;', '').trim() ?? '';
+          const unitPriceText = row.querySelector('td.ty-cart-content__price > span')?.text.replaceAll(',', '');
+          const unitPrice = parseInt(unitPriceText ?? '0', 10);
+          const qtyInput = row.querySelector('td.ty-cart-content__qty input.ty-value-changer__input');
+          const num = parseInt(qtyInput?.getAttribute('value') ?? '0', 10);
+          return {
+            name,
+            num,
+            link,
+            deleteLink,
+            code,
+            unitPrice,
+            totalPrice: unitPrice * num
+          };
+        });
+
       return {
-        name,
-        num,
-        link,
-        deleteLink,
-        code,
-        unitPrice,
-        totalPrice: unitPrice * num
+        id: 'cart',
+        status: 'cart',
+        orderedAt: new Date(),
+        details
       };
     });
-
-    return {
-      id: 'cart',
-      status: 'cart',
-      orderedAt: new Date(),
-      details
-    };
   }
 
-  public async addToCart(link: string): Promise<void> {
-    const params = new URLSearchParams();
-    const html = await this.fetcher.fetch(link);
-    const root = parse(html);
-    const form = root.querySelector('div.ty-product-block__left > form');
-    form?.querySelectorAll('input').forEach((input) => {
-      params.set(input.attributes.name, input.attributes.value);
+  public async addToCart(link: string): Promise<TaskQueueResult<void>> {
+    return this.enqueue(async () => {
+      await this.authenticate();
+      const params = new URLSearchParams();
+      const html = await this.fetcher.fetch(link);
+      const root = parse(html);
+      const form = root.querySelector('div.ty-product-block__left > form');
+      form?.querySelectorAll('input').forEach((input) => {
+        params.set(input.attributes.name, input.attributes.value);
+      });
+      form?.querySelectorAll('select').forEach((select) => {
+        params.set(select.attributes.name, select.attributes.value);
+      });
+      form?.querySelectorAll('button').forEach((button) => {
+        params.set(button.attributes.name, '');
+      });
+      const resp = await fetch('https://www.elineupmall.com/', {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/x-www-form-urlencoded; charset=UTF-8'
+        },
+        body: params.toString(),
+        credentials: 'include'
+      });
+      if (resp.status >= 400) {
+        throw new Error('invalid response code: ' + resp.status);
+      }
     });
-    form?.querySelectorAll('select').forEach((select) => {
-      params.set(select.attributes.name, select.attributes.value);
-    });
-    form?.querySelectorAll('button').forEach((button) => {
-      params.set(button.attributes.name, '');
-    });
-    const resp = await fetch('https://www.elineupmall.com/', {
-      method: 'POST',
-      headers: {
-        'content-type': 'application/x-www-form-urlencoded; charset=UTF-8'
-      },
-      body: params.toString(),
-      credentials: 'include'
-    });
-    if (resp.status >= 400) {
-      throw new Error('invalid response code: ' + resp.status);
-    }
   }
 
-  public async removeFromCart(detail: ElineupMallOrderDetail): Promise<void> {
-    if (detail.deleteLink === undefined) {
-      throw new Error('delete link is not available');
-    }
-    const resp = await fetch(detail.deleteLink, {
-      credentials: 'include'
+  public async removeFromCart(detail: ElineupMallOrderDetail): Promise<TaskQueueResult<void>> {
+    return this.enqueue(async () => {
+      await this.authenticate();
+      if (detail.deleteLink === undefined) {
+        throw new Error('delete link is not available');
+      }
+      const resp = await fetch(detail.deleteLink, {
+        credentials: 'include'
+      });
+      if (resp.status >= 400) {
+        throw new Error('invalid response code: ' + resp.status);
+      }
     });
-    if (resp.status >= 400) {
-      throw new Error('invalid response code: ' + resp.status);
-    }
   }
 }
 

--- a/expo/features/elineupmall/scraper/internals/types.ts
+++ b/expo/features/elineupmall/scraper/internals/types.ts
@@ -27,14 +27,10 @@ export type ElineupMallOrderDetail = {
   totalPrice: number;
 };
 
-export interface ElineupMallScraper {
-  authenticate(username: string, password: string): Promise<boolean>;
-  getOrderList(from: Date): Promise<ElineupMallOrder[]>;
-}
-
 export interface ElineupMallFetcher {
   postCredential(username: string, password: string): Promise<string>;
   fetch(url: string): Promise<string>;
+  fetchTop(): Promise<string>;
   fetchOrderListHtml(pageNum: number): Promise<string>;
   fetchOrderDetailHtml(id: string): Promise<string>;
   fetchCartHtml(): Promise<string>;

--- a/expo/foundation/TaskQueue.test.ts
+++ b/expo/foundation/TaskQueue.test.ts
@@ -1,0 +1,59 @@
+import TaskQueue, { TaskQueueResult } from './TaskQueue';
+
+class TaskQueueSample extends TaskQueue {
+  public readonly taskResult: string[] = [];
+
+  public async taskA(): Promise<TaskQueueResult<string>> {
+    return this.enqueue(async () => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          this.taskResult.push('A');
+          resolve('A');
+        }, 100);
+      });
+    });
+  }
+
+  public async taskB(): Promise<TaskQueueResult<string>> {
+    return this.enqueue(async () => {
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          this.taskResult.push('B');
+          resolve('B');
+        }, 0);
+      });
+    });
+  }
+
+  public async taskC(): Promise<TaskQueueResult<string>> {
+    return this.enqueue(async () => {
+      return new Promise((resolve, reject) => {
+        setTimeout(() => {
+          this.taskResult.push('C');
+          reject(new Error('error'));
+        }, 0);
+      });
+    });
+  }
+}
+
+describe('TaskQueue', () => {
+  test('enqueue', async () => {
+    const taskQueue = new TaskQueueSample();
+    // taskA is executed first while it wait for 100 msec, and taskB is executed after taskA is completed.
+    const [[a], [b]] = await Promise.all([taskQueue.taskA(), taskQueue.taskB()]);
+    expect(a).toBe('A');
+    expect(b).toBe('B');
+    expect(taskQueue.taskResult).toEqual(['A', 'B']);
+  });
+
+  test('enqueue with error', async () => {
+    const taskQueue = new TaskQueueSample();
+    const [[a], [c, err], [b]] = await Promise.all([taskQueue.taskA(), taskQueue.taskC(), taskQueue.taskB()]);
+    expect(a).toBe('A');
+    expect(b).toBe('B');
+    expect(c).toBe(undefined);
+    expect(err).toBeInstanceOf(Error);
+    expect(taskQueue.taskResult).toEqual(['A', 'C', 'B']);
+  });
+});

--- a/expo/foundation/TaskQueue.ts
+++ b/expo/foundation/TaskQueue.ts
@@ -1,0 +1,16 @@
+export type TaskQueueResult<T> = [T, undefined] | [undefined, Error];
+
+export default class TaskQueue {
+  private queue: Promise<void> = Promise.resolve();
+
+  enqueue<T>(task: () => Promise<T>): Promise<TaskQueueResult<T>> {
+    const resultPromise = this.queue.then(() =>
+      task().then(
+        (result) => [result, undefined] as [T, undefined],
+        (err) => [undefined, err] as [undefined, Error]
+      )
+    );
+    this.queue = resultPromise.then(() => {});
+    return resultPromise;
+  }
+}

--- a/expo/jest.setup.tsx
+++ b/expo/jest.setup.tsx
@@ -185,6 +185,12 @@ jest.mock('expo-sqlite', () => ({
   openDatabaseSync: jest.fn()
 }));
 
+jest.mock('@react-native-cookies/cookies', () => ({
+  set: jest.fn(),
+  get: jest.fn(),
+  clearAll: jest.fn()
+}));
+
 jest.mock('@hpapp/system/media', () => {
   const OriginalModule = jest.requireActual('@hpapp/system/media');
   const Mock = {


### PR DESCRIPTION
**Summary**

We noticed that elineupmall.com returns 500 error when the app swtich from `fetch` to `WebView` vice versa. We suspect that the cookie is not cleaned up properly. This change implements the cookie cleanup task.

This also implements serialization control of fetch accesses by TaskQueue logic between authentication and scraping cart/history data to make sure the session state do not change during the concurrent scraping processes.

**Test**

- expo

**Issue**

- N/A