### PR TITLE
[expo] add a tool to copy the token to clipboard

### DIFF
--- a/expo/features/devtool/internals/DevtoolListItem.tsx
+++ b/expo/features/devtool/internals/DevtoolListItem.tsx
@@ -1,4 +1,6 @@
 import { ListItemKeyValue } from '@hpapp/features/common/list';
+import * as Clipboard from 'expo-clipboard';
+import Toast from 'react-native-root-toast';
 
 export default function DevtoolListItem({
   name,
@@ -18,6 +20,8 @@ export default function DevtoolListItem({
         // intentional console output so that developer can copy on their terminal.
         // eslint-disable-next-line no-console
         console.log('Settings', name, ':', value);
+        Clipboard.setStringAsync(value);
+        Toast.show('copied to clipboard');
       }}
     />
   );


### PR DESCRIPTION
**Summary**

we want to copy access token to clipboard to do some debugging in production/beta binary.

**Test**

- expo

**Issue**

- N/A