### PR TITLE
[expo] update Android package name

### DIFF
--- a/expo/config/beta/app.config.js
+++ b/expo/config/beta/app.config.js
@@ -10,13 +10,13 @@ module.exports = (config) => {
   // bundleID used in your Apple Developer Account
   config.ios.bundleIdentifier = 'dev.yssk22.hpapp.beta';
   // package name used in your Goolge Developer Account
-  config.android.package = 'dev.yssk22.hpapp.beta.android';
+  config.android.package = 'dev.yssk22.hellofanapp.beta';
   config.extra.hpapp.env = 'beta';
   config.extra.hpapp.isBeta = true;
   config.extra.hpapp.isDev = false;
   config.extra.hpapp.firebaseIOSClientID = '265427540400-kbuq50tafej5vhrtfdldi6ob61o0jrcu.apps.googleusercontent.com';
   config.extra.hpapp.firebaseAndroidClientID =
-    '265427540400-hl4b6t82h8d9jg7eemovlsftrn0c6tog.apps.googleusercontent.com';
+    '265427540400-s1mtg9uipl4vrbglmegoui9lli5mnb32.apps.googleusercontent.com';
 
   config.updates.url = 'https://u.expo.dev/a76e7e46-e508-43cf-93a8-1ae32871d4f7';
   return config;

--- a/expo/config/dev/app.config.js
+++ b/expo/config/dev/app.config.js
@@ -10,13 +10,13 @@ module.exports = (config) => {
   // bundleID used in your Apple Developer Account
   config.ios.bundleIdentifier = 'dev.yssk22.hpapp.dev';
   // package name used in your Goolge Developer Account
-  config.android.package = 'dev.yssk22.hpapp.dev.android';
+  config.android.package = 'dev.yssk22.hellofanapp.dev';
   config.extra.hpapp.env = 'dev';
   config.extra.hpapp.isBeta = false;
   config.extra.hpapp.isDev = true;
   // those id can be easily found in the URL in the browser in development
   config.extra.hpapp.firebaseIOSClientID = '265427540400-pq3vj6jg3p1pcrk55odp2v8k98l3jiir.apps.googleusercontent.com';
   config.extra.hpapp.firebaseAndroidClientID =
-    '265427540400-uomdcbi3g35i3242t7pkua8fhtvppnmq.apps.googleusercontent.com';
+    '265427540400-f969v5trl6vuls8ucf8dd5alogvcm1k0.apps.googleusercontent.com';
   return config;
 };

--- a/expo/config/prod/app.config.js
+++ b/expo/config/prod/app.config.js
@@ -10,14 +10,14 @@ module.exports = (config) => {
   // bundleID used in your Apple Developer Account
   config.ios.bundleIdentifier = 'dev.yssk22.hpapp';
   // package name used in your Goolge Developer Account
-  config.android.package = 'dev.yssk22.hpapp.android';
+  config.android.package = 'dev.yssk22.hellofanapp';
   config.extra.hpapp.env = 'prd';
   config.extra.hpapp.isBeta = false;
   config.extra.hpapp.isDev = false;
   // those id can be easily found in the URL in the browser in development buildsecrets.json
   config.extra.hpapp.firebaseIOSClientID = '265427540400-um42nfj6a2d2i59u7j01pmgpijmqk1oc.apps.googleusercontent.com';
   config.extra.hpapp.firebaseAndroidClientID =
-    '265427540400-e5jjgjmvm0ar0cnqn20lf27ncpj68jst.apps.googleusercontent.com';
+    '265427540400-9mnmj5pcrf1sl1c15rqutgdgdtula58o.apps.googleusercontent.com';
   config.updates.url = 'https://u.expo.dev/a76e7e46-e508-43cf-93a8-1ae32871d4f7';
   return config;
 };

--- a/expo/package.json
+++ b/expo/package.json
@@ -14,9 +14,9 @@
     "typecheck": "yarn tsc --noEmit",
     "genscreen": "node ./scripts/genscreen.js",
     "build-ios-dev": "HPAPP_CONFIG_NAME=dev ./scripts/eas.sh build --profile dev --platform ios --non-interactive",
-    "build-android-dev": "HPAPP_CONFIG_NAME=dev ./scripts/eas.sh build --profile dev --platform android --non-interactive --local --output ./build/hpapp-dev.apk",
-    "build-android-beta": "HPAPP_CONFIG_NAME=beta ./scripts/eas.sh build --profile beta --platform android --non-interactive --local --output ./build/hpapp-beta.aab",
-    "build-android-prod": "HPAPP_CONFIG_NAME=prod ./scripts/eas.sh build --profile prod --platform android --non-interactive --local --output ./build/hpapp-prod.aab",
+    "build-android-dev": "HPAPP_CONFIG_NAME=dev ./scripts/eas.sh build --profile dev --platform android --local --output ./build/hpapp-dev.apk",
+    "build-android-beta": "HPAPP_CONFIG_NAME=beta ./scripts/eas.sh build --profile beta --platform android --local --output ./build/hpapp-beta.aab",
+    "build-android-prod": "HPAPP_CONFIG_NAME=prod ./scripts/eas.sh build --profile prod --platform android --local --output ./build/hpapp-prod.aab",
     "update-beta": "HPAPP_CONFIG_NAME=beta ./scripts/eas.sh update --channel beta --message 'testing' --non-interactive",
     "storybook-generate": "sb-rn-get-stories"
   },


### PR DESCRIPTION
**Summary**

dev.yssk22.hpapp.android was moved to the organization developer account but it was still being blocked by 12 testers policy.

Then I created a new app in the org dev account, it is not being blocked so it looks like the policy doesn't appliy for apps created by the org account.

To use apps in the org account, we need new package names.

**Test**

- N/A

**Issue**

- N/A