### PR TITLE
[expo] fix upsertFollow

### DIFF
--- a/expo/features/artist/internals/useUpsertFollow.ts
+++ b/expo/features/artist/internals/useUpsertFollow.ts
@@ -82,12 +82,15 @@ const useUpsertFollow = (): [(params: UpsertFollowParams) => Promise<string>, bo
           },
           updater: (store, payload) => {
             const followId = payload?.me?.upsertFollow?.id;
-            const aristOrMember = store.get(obj.id) ?? undefined;
-            if (followId === undefined || aristOrMember === undefined) {
+            const artistOrMember = store.get(obj.id) ?? undefined;
+            if (followId === undefined || artistOrMember === undefined) {
               return;
             }
-            const record = aristOrMember.getOrCreateLinkedRecord('myFollowStatus', 'HPFollow');
-            record.setValue(followId, 'id');
+            const record = store.get(followId);
+            if (record === undefined || record === null) {
+              return;
+            }
+            artistOrMember.setLinkedRecord(record, 'myFollowStatus');
             record.setValue(followType, 'type');
             (elineupMallFollowParams ?? []).forEach((param) => {
               switch (param.category) {


### PR DESCRIPTION
**Summary**

we should not use getOrCreateLinkedRecord to create a new record, because it will create a new record even if the record already exists. Instead, we should take a record proxy from the given HPFollow id, then set it to the linked record on HPArtist or HPMember so that HPFollow and HPArtist/Member are fully linked and consistent.

**Test**

- expo

**Issue**

- #243